### PR TITLE
More proper description of template handler

### DIFF
--- a/lib/jbuilder_template.rb
+++ b/lib/jbuilder_template.rb
@@ -18,8 +18,9 @@ class JbuilderTemplate < Jbuilder
     end
 end
 
-class JbuilderHandler < ActionView::Template::Handler
-  self.default_format = Mime::JSON
+class JbuilderHandler
+  cattr_accessor :default_format
+  @@default_format = Mime::JSON
 
   def self.call(template)
     %{


### PR DESCRIPTION
Template handler rewritten as a class instead of Proc to:

1) Improve readability
2) Set default_format to Mime::JSON which allows to skip dummy type-dependent code in controllers and makes it not to include layout by default. Both are quite expected behaviors for JSON templates (that's how all the alternative libraries work and I can't believe it's a feature).
