### PR TITLE
Dynamically set a key/nested child with block

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -18,8 +18,28 @@ class Jbuilder < BlankSlate
   end
 
   # Dynamically set a key value pair.
-  def set!(key, value)
-    @attributes[key] = value
+  #
+  # Example:
+  #
+  #   json.set!(:each, "stuff")
+  #
+  #   { "each": "stuff" }
+  #
+  # You can also pass a block for nested attributes
+  #
+  #   json.set!(:author) do |json|
+  #     json.name "David"
+  #     json.age 32
+  #   end
+  #
+  #   { "author": { "name": "David", "age": 32 } }
+  def set!(*args)
+    case
+    when args.one? && block_given?
+      _yield_nesting(args.first) { |jbuilder| yield jbuilder }
+    when args.many?
+      @attributes[args.first] = args.second
+    end
   end
 
   # Turns the current element into an array and yields a builder to add a hash.

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -225,4 +225,18 @@ class JbuilderTest < ActiveSupport::TestCase
     
     assert_equal "stuff", JSON.parse(json)["each"]
   end
+
+  test "dynamically set a key/nested child with block" do
+    json = Jbuilder.encode do |json|
+      json.set!(:author) do |json|
+        json.name "David"
+        json.age 32
+      end
+    end
+    
+    JSON.parse(json).tap do |parsed|
+      assert_equal "David", parsed["author"]["name"]
+      assert_equal 32, parsed["author"]["age"]
+    end
+  end
 end


### PR DESCRIPTION
This allows more complex dynamic key assignment than simply a value.

I'm a bit worried that the new implementation of set! doesn't raise an exception if it's used with too many arguments, I'm very happy to make any changes you suggest.

Cheers,

Matt Gibb.
