### PR TITLE
Added methods to turn off serialization of nil attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can configure Jbuilder to not serialize nil values.  By default nil values w
 
 ``` ruby
 # You can set the default behavior of all Jbuilder instances to not serialize nil
-Jbuilder.serialize_nil false
+Jbuilder.serializes_nil false
 
 json.author do |json|
   json.name nil
@@ -104,7 +104,7 @@ end
 
 # Or you can set the behavior per instance
 json.author do |json|
-  json.serialize_nil! false
+  json.serializes_nil! false
   json.name nil
   json.age 32
 end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -62,7 +62,10 @@ class Jbuilder < BlankSlate
   #   end  
   def child!
     @attributes = [] unless @attributes.is_a? Array
-    @attributes << _new_instance._tap { |jbuilder| yield jbuilder }.attributes!
+    @attributes << (_new_instance._tap do |jbuilder| 
+      jbuilder.serializes_nil! @serializes_nil
+      yield jbuilder 
+    end.attributes!)
   end
 
   # Turns the current element into an array and iterates over the passed collection, adding each iteration as 
@@ -213,7 +216,10 @@ class Jbuilder < BlankSlate
     end
 
     def _yield_nesting(container)
-      set! container, _new_instance._tap { |jbuilder| yield jbuilder }.attributes!
+      set! container, (_new_instance._tap do |jbuilder| 
+        jbuilder.serializes_nil! @serializes_nil
+        yield jbuilder 
+      end.attributes!)
     end
 
     def _inline_nesting(container, collection, attributes)

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -293,4 +293,32 @@ class JbuilderTest < ActiveSupport::TestCase
     # reset default value
     Jbuilder.serializes_nil true
   end
+
+  test "child key with nil value and serializes_nil disabled" do
+    json = Jbuilder.encode do |json|
+      json.serializes_nil! false
+      json.author do |json|
+        json.name nil
+        json.age  32
+      end
+    end
+
+    assert !JSON.parse(json).has_key?("name")
+  end
+
+  test "child key with nil value and default serializes_nil disabled" do
+    Jbuilder.serializes_nil false
+    json = Jbuilder.encode do |json|
+      json.author do |json|
+        json.name nil
+        json.age  32
+      end
+    end
+
+    assert !JSON.parse(json).has_key?("name")
+
+    # reset default value
+    Jbuilder.serializes_nil true
+  end
+
 end


### PR DESCRIPTION
This adds the ability to turn off serialization of nil attributes by default or on a per instance basis via a class and instance method respectively.  The default behavior if neither method is called is to continue serializing nil attributes.

``` ruby
# You can set the default behavior of all Jbuilder instances to not serialize nil
Jbuilder.serializes_nil false

json.author do |json|
  json.name nil
  json.age 32
end
# => { author: {"age": 32 } }

# Or you can set the behavior per instance
json.author do |json|
  json.serializes_nil! false
  json.name nil
  json.age 32
end
# => { author: {"age": 32 } }
```
