### PR TITLE
API to coax the encoding of null values for arrays of JSON objects

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -95,6 +95,25 @@ class Jbuilder < BlankSlate
       end
     end
   end
+  
+  # Sets the current attributes to nil, such that the resulting JSON will be 'null'. This is useful for
+  # encoding a complex array elements as 'null' instead of '{}'.
+  #
+  # Example:
+  #
+  #  json.people @people do |json, person|
+  #    if person
+  #      json.name person.name
+  #      json.age person.age
+  #    else
+  #      json.null!
+  #    end
+  #  end
+  #
+  #  {"people": [{"name":"David", "age":32}, nil]}
+  def null!
+    @attributes = nil
+  end
 
   # Extracts the mentioned attributes from the passed object and turns them into attributes of the JSON.
   #

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -256,4 +256,54 @@ class JbuilderTest < ActiveSupport::TestCase
       assert_equal 32, parsed["author"]["age"]
     end
   end
+  
+  test "array of Strings with nil value" do
+    json = Jbuilder.encode do |json|
+      json.data(["hello", nil, "world"])
+    end
+
+    JSON.parse(json).tap do |parsed|
+      assert_equal "hello", parsed['data'].first
+      assert_nil parsed['data'].second
+      assert_equal "world", parsed['data'].third
+    end
+  end
+
+  test "array of Structs with nil value" do
+    comments = [ Struct.new(:content).new("hello"), nil ]
+
+    json = Jbuilder.encode do |json|
+      json.data(comments) do |json, comment|
+        if comment
+          json.content comment.content
+        else
+          json.null!
+        end
+      end
+    end
+    
+    JSON.parse(json).tap do |parsed|
+      assert_equal "hello", parsed['data'].first["content"]
+      assert_nil parsed['data'].second
+    end
+  end
+  
+  test "array of top-level Structs with nil value" do
+    comments = [ Struct.new(:content).new("hello"), nil ]
+
+    json = Jbuilder.encode do |json|
+      json.array!(comments) do |json, comment|
+        if comment
+          json.content comment.content
+        else
+          json.null!
+        end
+      end
+    end
+    
+    JSON.parse(json).tap do |parsed|
+      assert_equal "hello", parsed.first["content"]
+      assert_nil parsed.second
+    end
+  end
 end


### PR DESCRIPTION
With my current understanding of the Jbuilder API, there's no means for creating the following JSON -

``` JSON
{"people":[{"name":"Bob Tables"},null,{"name":"Jim Pools"}]}
```

For example, the following snippet encodes an empty JSON object instead of null.

``` RUBY
require 'jbuilder'

people = [{fn:"Bob", ln:"Tables"}, nil, {fn:"Jim", ln:"Pools"}]

json = Jbuilder.encode do |json|
  json.people(people) do |json, person|
    if person
      json.name "#{person[:fn]} #{person[:ln]}"
    end
  end
end

puts json
```

This example outputs the following -

``` JSON
{"people":[{"name":"Bob Tables"},{},{"name":"Jim Pools"}]}
```

The attached code adds an additional 'null!' method, which can be used to indicate that a null encoding is desired instead. The above example could then be tweaked to this -

``` RUBY
require 'jbuilder'

people = [{fn:"Bob", ln:"Tables"}, nil, {fn:"Jim", ln:"Pools"}]

json = Jbuilder.encode do |json|
  json.people(people) do |json, person|
    if person
      json.name "#{person[:fn]} #{person[:ln]}"
    else
      json.null!
    end
  end
end

puts json
```

This example outputs the following -

``` JSON
{"people":[{"name":"Bob Tables"},null,{"name":"Jim Pools"}]}
```

The API is slightly awkward and I'm not too sure about the implementation, so I'm open to comments and suggestions on a better approach. Just let me know and I rework it.
