### PR TITLE
Correct misalligned line numbers wher JBuilder reports errors

### DIFF
--- a/lib/jbuilder_template.rb
+++ b/lib/jbuilder_template.rb
@@ -30,15 +30,10 @@ class JbuilderHandler
   self.default_format = Mime::JSON
 
   def self.call(template)
-    %{
-      if defined?(json)
-        #{template.source}
-      else
-        JbuilderTemplate.encode(self) do |json|
-          #{template.source}
-        end
-      end
-    }
+    
+    # this juggling is required to keep line numbers right in the error
+    %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{template.source}
+      json.target! unless __already_defined}
   end
 end
 


### PR DESCRIPTION
Since the source is "sourced" twice JbuilderHandler it is causing all the lines in the error messages to be totally bogus.  

This patch keeps the lines aligned that in turn ensure you get the correct error line numbers.

It does slightly change stuff by adding a local, nonetheless I think it is safe.  
