### PR TITLE
Added support for hashes for the extract! method.

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -138,9 +138,15 @@ class Jbuilder < BlankSlate
     end
   end
 
-  # Extracts the mentioned attributes from the passed object and turns them into attributes of the JSON.
+  # Extracts the mentioned attributes or hash elements from the passed object and turns them into attributes of the JSON.
   #
   # Example:
+  #
+  #   @person = Struct.new(:name, :age).new("David", 32)
+  #
+  #   or you can utilize a Hash
+  #
+  #   @person = {:name => "David", :age => 32}
   #
   #   json.extract! @person, :name, :age
   #
@@ -150,9 +156,13 @@ class Jbuilder < BlankSlate
   #
   #   json.(@person, :name, :age)
   def extract!(object, *attributes)
-    attributes.each do |attribute|
-      __send__ attribute, object.send(attribute)
+    p = if object.is_a?(Hash)
+      lambda{|attribute| __send__ attribute, object.send(:fetch, attribute)}
+    else
+      lambda{|attribute| __send__ attribute, object.send(attribute)}
     end
+
+    attributes.each{|attribute| p.call(attribute)}
   end
 
   if RUBY_VERSION > '1.9'

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -67,7 +67,20 @@ class JbuilderTest < ActiveSupport::TestCase
       assert_equal 32, parsed["age"]
     end
   end
-  
+
+  test "extracting from hash" do
+    person = {:name => "Jim", :age => 34}
+
+    json = Jbuilder.encode do |json|
+      json.extract! person, :name, :age
+    end
+
+    JSON.parse(json).tap do |parsed|
+      assert_equal "Jim", parsed["name"]
+      assert_equal 34, parsed["age"]
+    end
+  end
+
   test "nesting single child with block" do
     json = Jbuilder.encode do |json|
       json.author do |json|


### PR DESCRIPTION
extract! can now take a Hash object and associated keys and will generate json output anaologous to an object and it's declared output attributes.

So, instead of using a set! with hash key/values:

```
questions = [{:text => "Question 1"}, {:text => "Question 2"}]

json.array!(security_questions) do |json, security_question|
  json.set!(:text, security_question[:text])
end
```

It can now be achieved with the same syntax as a normal object:

```
json.array!(security_questions) do |json, security_question|
  json.(security_question, :text)
end
```
