### PR TITLE
Enforcing json format for partial!

### DIFF
--- a/lib/jbuilder_template.rb
+++ b/lib/jbuilder_template.rb
@@ -9,9 +9,9 @@ class JbuilderTemplate < Jbuilder
     when ::Hash
       options[:locals] ||= {}
       options[:locals].merge!(:json => self)
-      @context.render(options)
-    else
-      @context.render(options, locals.merge(:json => self))
+      @context.render(options.reverse_merge(:formats => [:json]))
+    else # String
+      @context.render(:partial => options, :locals => locals.merge(:json => self), :formats => [:json])
     end
   end
 


### PR DESCRIPTION
This change fixed an error I encountered where jbuilder template tried to look for `:format => [:html]` on `partial!` call when the initial jbuilder partial invokation happened from within helper inside html view.
