### PR TITLE
Improve test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "http://rubygems.org"
 gemspec
 
 gem "actionpack"
+gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       rack (>= 0.4)
     rack-test (0.6.1)
       rack (>= 1.0)
+    rake (0.9.2.2)
     sprockets (2.1.3)
       hike (~> 1.2)
       rack (~> 1.0)
@@ -46,3 +47,4 @@ PLATFORMS
 DEPENDENCIES
   actionpack
   jbuilder!
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'bundler'
+require 'rake/testtask'
+
+Bundler.require
+
+Rake::TestTask.new do |test|
+  test.test_files = FileList["test/*_test.rb"]
+end
+
+task :default => :test


### PR DESCRIPTION
This PR improves the test suite. The Jbuilder template handler is now tested with `ActionView::TestCase`, which makes the tests much more reliable. A test is added for partial rendering which should catch errors such as the one fixed in #60. It also introduces a `Rakefile` that makes it easy to run all tests with just `rake`.
