### PR TITLE
.each.map is redundant. In most cases it's equivalent to .map, but it fails with mongoid 2.4

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -263,7 +263,7 @@ class Jbuilder < ActiveSupport::BasicObject
     end
 
     def _map_collection(collection)
-      collection.each.map do |element|
+      collection.map do |element|
         _scope { yield element }
       end
     end


### PR DESCRIPTION
Hi @dhh,

I suppose it's a typo. I did a search and no clues on why call `.each.map` instead of just `.map`. `.each` returns an `Enumerator` which has the `.map` method since `Enumerable` module is included in this class. Basically they are the same.

Mongoid 2.4.x has a weird behavior that an empty `Mongoid::Relations::Targets::Enumerable` returns `true` when `.each` is received. To avoid this, I suggest removing `.each.map`. I think it's simple enough so that I didn't attach any test cases.

Best.
