### PR TITLE
Support collections that are not Enumerable

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -292,7 +292,7 @@ class Jbuilder < JbuilderProxy
             value
           end
         else
-          if value.kind_of?(::Enumerable)
+          if value.respond_to?(:map)
             # json.comments(@post.comments, :content, :created_at)
             # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
             _map_collection(value) do |element|


### PR DESCRIPTION
ActiveRecord Relations are not `Enumerable`, however do respond to `#map`, so checking that the value responds to `#map` rather than being an `Enumerable` to prevent having to manually convert relations to arrays via `#to_a` before passing to Jbuilder.

Fixes a regression introduced at 74d78bf and adds tests for this explicit case.
