### PR TITLE
add license information to the gemspec

### DIFF
--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.author  = 'David Heinemeier Hansson'
   s.email   = 'david@37signals.com'
   s.summary = 'Create JSON structures via a Builder-style DSL'
+  s.license = 'MIT'
 
   s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_development_dependency 'rake', '~> 10.0.3'


### PR DESCRIPTION
this way you can get it when using rubygems.org API
