### PR TITLE
Use `git ls-files` to create the file list for the gem

### DIFF
--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -9,5 +9,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_development_dependency 'rake', '~> 10.0.3'
 
-  s.files = Dir["#{File.dirname(__FILE__)}/**/*"]
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- test/*`.split("\n")
 end


### PR DESCRIPTION
Fixes an issue with the gem for jbuilder 1.0.2
which includes 3 .gem files inside
