### PR TITLE
Key name from a variable/method

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -239,6 +239,18 @@ class Jbuilder < JbuilderProxy
     end
   end
 
+  # Almost same as using json.key, but with key passed explicitly as an argument
+  # 
+  # common_collections_map.each do |key, collection|
+  #   json.key! key, collection  do |item|
+  #     json.call item, :name
+  #   end
+  # end
+  # 
+  def key! name, *args, &block
+    _build name, *args, &block
+  end
+
   def call(object = nil, *attributes)
     if attributes.empty?
       array!(object, &::Proc.new)
@@ -268,7 +280,11 @@ class Jbuilder < JbuilderProxy
 
     BLANK = ::Object.new
 
-    def method_missing(method, value = BLANK, *args, &block)
+    def method_missing(method, *args, &block)
+      _build method, *args, &block
+    end
+
+    def _build(method, value = BLANK, *args, &block)
       result = if ::Kernel.block_given?
         if BLANK != value
           # json.comments @post.comments { |comment| ... }

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -89,6 +89,28 @@ class JbuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test 'building by name using []' do
+    json = Jbuilder.encode do |json|
+      json.key! :key, 'value'
+    end
+
+    MultiJson.load(json).tap do |parsed|
+      assert_equal 'value', parsed['key']
+    end
+  end
+
+  test 'nested building by name using []' do
+    json = Jbuilder.encode do |json|
+      json.key! :author do |json|
+        json.name 'David'
+      end
+    end
+
+    MultiJson.load(json).tap do |parsed|
+      assert_equal 'David', parsed['author']['name']
+    end
+  end
+
   test 'extracting from hash' do
     person = {:name => 'Jim', :age => 34}
 


### PR DESCRIPTION
It may be useful to pass keyname for json from somewhere else (look at example below).

``` ruby
common_collections_map.each do |key, collection|
  json.key! key, collection  do |item|
    json.call item, :name
  end
end
```

common_collections - hash, mapping some name with some common collections (i.e. different types of tags) which should be included in json.
