### PR TITLE
Adding the missing opening quotes for the names

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ json.array!(@people) do |person|
   json.age calculate_age(person.birthday)
 end
 
-# => [ { "name": David", "age": 32 }, { "name": Jamie", "age": 31 } ]
+# => [ { "name": "David", "age": 32 }, { "name": "Jamie", "age": 31 } ]
 ```
 
 Jbuilder objects can be directly nested inside each other.  Useful for composing objects.


### PR DESCRIPTION
I noticed the opening quotes were missing around the names `David` and `Jamie`. This change would make it accurate.
