### PR TITLE
Add is_a? as an instance method on Jbuilder

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -274,6 +274,24 @@ class Jbuilder < JbuilderProxy
     ::MultiJson.dump @attributes
   end
 
+  # Implementation of is_a? to support the internal workings
+  # of the Jbuilder class.
+  #
+  # Note: this method name breaks the pattern of all method names ending
+  # in '!'.  It is still possible to define a key with value 'is_a?', but
+  # it requires direct use of the set! command.  Example:
+  #
+  # json.set! :is_a? "test"
+  # { "is_a?": "test" }
+  #
+  # Note: This implementation ensures the correct behavior
+  # for set! for subclasses of Jbuilder, but it will not 
+  # behave in a way consistent with Object::is_a?
+  # for subclasses of Jbuilder.  This is expected behavior.
+  def is_a?(klass)
+    klass == ::Jbuilder
+  end
+
   private
 
     def _set_value(key, value)

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -339,6 +339,7 @@ class JbuilderTest < ActiveSupport::TestCase
     parsed = MultiJson.load(json)
     assert_equal 'Test', parsed['value']
     assert_equal 'Nested Test', parsed['nested']['nested_value']
+    assert_equal 1, parsed['nested'].size
   end
 
   test 'top-level array' do
@@ -373,6 +374,14 @@ class JbuilderTest < ActiveSupport::TestCase
     end
 
     assert_equal 'stuff', MultiJson.load(json)['each']
+  end
+
+  test 'dynamically set a value with key :is_a?' do
+    json = Jbuilder.encode do |json|
+      json.set! :is_a?, 'stuff'
+    end
+
+    assert_equal 'stuff', MultiJson.load(json)['is_a?']
   end
 
   test 'dynamically set a key/nested child with block' do


### PR DESCRIPTION
This pull request is intended to resolve issue #116 in the simplest way, with the minimal impact on the behavior of the Jbuilder class.  This pull request includes:

i) An update to the nested Jbuilder test that causes it to test for the existence of spurious keys in the nested JSON hash and fails against current master
ii) A barebones implementation of is_a? on Jbuilder
iii) A new test to ensure that a user of the Jbuilder library can create a key "is_a?" using the set! method

There's an unfortunate consequence of this change that may or may not be acceptable - a user can no longer call is_a? on a builder object to create a key 'is_a?' in the JSON.  This seemed like a reasonable tradeoff to me, but others may certainly feel differently.  

Even given this consequence, this pull request seems like the simplest way to resolve issue #116.    
