### PR TITLE
Allow nil values in set!

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -98,6 +98,8 @@ class Jbuilder < JbuilderProxy
       # json.comments @post.comments, :content, :created_at
       # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
       _map_collection(value){ |element| extract! element, *args }
+    elsif value.nil?
+      value
     else
       # json.author @post.creator, :name, :email_address
       # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }


### PR DESCRIPTION
This very simple change, which [passes all existing tests](https://travis-ci.org/bpartridge/jbuilder/builds/5798329), allows you to pass optional relationships directly to `json.related_thing object.related_thing, :id, :name` without first checking if `object.related_thing.nil?`. If necessary, I'd be glad to write tests and documentation for this new functionality, but I'm just submitting this pull request to track the change.
