### PR TITLE
Allow templates with alternate mime types

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -9,9 +9,9 @@ class JbuilderTemplate < Jbuilder
     when ::Hash
       options[:locals] ||= {}
       options[:locals].merge!(:json => self)
-      @context.render(options.reverse_merge(:formats => [:json]))
+      @context.render(options)
     else # String
-      @context.render(:partial => options, :locals => locals.merge(:json => self), :formats => [:json])
+      @context.render(:partial => options, :locals => locals.merge(:json => self))
     end
   end
 


### PR DESCRIPTION
Trying to use jbuilder with an alternative mime type (eg, `application/hal+json`) does not work for partial templates because jbuilder forcibly sets the format to `:json` in the `#partial!` method. This is the error I get:

```
Started GET "/accounts" for 127.0.0.1 at 2013-04-01 16:41:59 -0600
Processing by AccountsController#index as HAL
  Account Load (0.2ms)  SELECT "accounts".* FROM "accounts"
  Credentials Load (0.2ms)  SELECT "credentials".* FROM "credentials" WHERE "credentials"."account_id" IN (1)
  Rendered accounts/index.hal.jbuilder (30.7ms)
Completed 500 Internal Server Error in 32ms

ActionView::Template::Error (Missing partial accounts/account with {:locale=>[:en], :formats=>[:json], :handlers=>[:erb, :builder, :raw, :ruby, :jbuilder]}. Searched in:
  * "/Users/rando/Code/librato/cloudsnarf/app/views"
):
     8:   json.self link(accounts_url)
     9: end
    10: json._embedded do
    11:   json.accounts(@accounts) { |account| json.partial! account }
    12: end
  app/views/accounts/index.hal.jbuilder:11:in `block (2 levels) in _app_views_accounts_index_hal_jbuilder___3338183405941646797_70245895658780'
  app/views/accounts/index.hal.jbuilder:11:in `block in _app_views_accounts_index_hal_jbuilder___3338183405941646797_70245895658780'
  app/views/accounts/index.hal.jbuilder:10:in `_app_views_accounts_index_hal_jbuilder___3338183405941646797_70245895658780'


  Rendered /Users/rando/.rvm/gems/ruby-2.0.0-p0@cloudsnarf/gems/actionpack-4.0.0.beta1/lib/action_dispatch/middleware/templates/rescues/_trace.erb (1.1ms)
  Rendered /Users/rando/.rvm/gems/ruby-2.0.0-p0@cloudsnarf/gems/actionpack-4.0.0.beta1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb (0.8ms)
  Rendered /Users/rando/.rvm/gems/ruby-2.0.0-p0@cloudsnarf/gems/actionpack-4.0.0.beta1/lib/action_dispatch/middleware/templates/rescues/template_error.erb within rescues/layout (8.4ms)
```

I make a request with `Accept: application/hal+json`, Rails finds the `accounts/index.hal.jbuilder` template, and loads it correctly. That template uses the "account" partial, but because the `#partial!` method sets the format to `:json`, Rails tries to find a `accounts/_account.json.jbuilder` template, while I have it named `accounts/_account.hal.jbuilder`.

This change just removes setting the format. I'm not sure the original purpose of it, and all the tests pass without it.
