### PR TITLE
fixes undefined local variable or method attributes_names

### DIFF
--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -29,10 +29,10 @@ module Rails
         end
 
         def attributes_list_with_timestamps
-          attributes_list(attributes_names + %w(created_at updated_at))
+          attributes_list(attributes.map(&:name) + %w(created_at updated_at))
         end
 
-        def attributes_list(attributes = attributes_names)
+        def attributes_list(attributes = attributes.map(&:name))
           if self.attributes.any? {|attr| attr.name == 'password' && attr.type == :digest}
             attributes = attributes.reject {|name| %w(password password_confirmation).include? name}
           end


### PR DESCRIPTION
I set in rails_app/config/application.rb,

```
config.generators.template_engine :jbuilder
```

and run command.

```
rails g scaffold Post title body:text
```

I found a error.

```
jbuilder_generator.rb:35:in `attributes_list': undefined local variable or method `attributes_names'
```

Rails version is 3.2.13 and ruby is 1.9.3.

This codes maybe fix it, but I don't know how to test generators.
