### PR TITLE
Require MIME dependency explicitly

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -1,3 +1,5 @@
+require 'action_dispatch/http/mime_type'
+
 class JbuilderTemplate < Jbuilder
   def initialize(context, *args, &block)
     @context = context


### PR DESCRIPTION
There is an exception without this patch.

The exception is `uninitialized constant JbuilderHandler::Mime (NameError)`

I'm running little bit unusual stack where I share `ActiveRecord` models between `Rails` 
and another `non-Rails` lightweight application.
