### PR TITLE
whitelist and blacklist keys on Jbuilder#array!

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Jbuilder.encode do |json|
     json.filename attachment.filename
     json.url url_for(attachment)
   end
+
+  json.attachments @message.attachments, except: [:filename] do |attachment|
+    json.filename attachment.filename
+    json.url url_for(attachment)
+  end
+
+  json.attachments @message.attachments, only: [:filename] do |attachment|
+    json.filename attachment.filename
+    json.url url_for(attachment)
+  end
 end
 ```
 
@@ -51,6 +61,16 @@ This will build the following structure:
   "attachments": [
     { "filename": "forecast.xls", "url": "http://example.com/downloads/forecast.xls" },
     { "filename": "presentation.pdf", "url": "http://example.com/downloads/presentation.pdf" }
+  ]
+
+  "attachments": [
+    { "url": "http://example.com/downloads/forecast.xls" },
+    { "url": "http://example.com/downloads/presentation.pdf" }
+  ]
+
+  "attachments": [
+    { "filename": "forecast.xls" },
+    { "filename": "presentation.pdf" }
   ]
 }
 ```
@@ -84,6 +104,30 @@ You can also extract attributes from array directly.
 json.array! @people, :id, :name
 
 # => [ { "id": 1, "name": "David" }, { "id": 2, "name": "Jamie" } ]
+```
+
+You can also exclude predefined keys to be rendered.
+
+``` ruby
+# @people = People.all
+json.people @people, except: [:id] do |person|
+  json.id person.id
+  json.name person.name
+end
+
+# => [ { name": "David" }, { "name": "Jamie" } ]
+```
+
+You can also select predefined keys to be rendered.
+
+``` ruby
+# @people = People.all
+json.people @people, only: [:id] do |person|
+  json.id person.id
+  json.name person.name
+end
+
+# => [ { "id": 1 }, { "id": 2 } ]
 ```
 
 

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -388,6 +388,40 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal       2, parsed.second['id']
   end
 
+  test 'extract attributes directly from array except listed keys' do
+    comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
+
+    json = Jbuilder.encode do |json|
+      json.comments comments, except: [:content] do |comment|
+        json.content comment.content
+        json.id comment.id
+      end
+    end
+
+    parsed = MultiJson.load(json)
+    assert_equal nil, parsed['comments'].first['content']
+    assert_equal   1, parsed['comments'].first['id']
+    assert_equal nil, parsed['comments'].second['content']
+    assert_equal   2, parsed['comments'].second['id']
+  end
+
+  test 'extract attributes directly from array only listed keys' do
+    comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
+
+    json = Jbuilder.encode do |json|
+      json.comments comments, only: [:content] do |comment|
+        json.content comment.content
+        json.id comment.id
+      end
+    end
+
+    parsed = MultiJson.load(json)
+    assert_equal 'hello', parsed['comments'].first['content']
+    assert_equal     nil, parsed['comments'].first['id']
+    assert_equal 'world', parsed['comments'].second['content']
+    assert_equal     nil, parsed['comments'].second['id']
+  end
+
   test 'empty top-level array' do
     comments = []
 


### PR DESCRIPTION
As addition to #array! method, it would be great if we can whitelist and blacklist predefined keys.

``` ruby
# @people = People.all
json.people @people, except: [:id] do |person|
  json.id person.id
  json.name person.name
end

# => [ { name": "David" }, { "name": "Jamie" } ]

# @people = People.all
json.people @people, only: [:id] do |person|
  json.id person.id
  json.name person.name
end

# => [ { "id": 1 }, { "id": 2 } ]
```

**Why?**

This similar with [Google Partial Response](https://developers.google.com/youtube/2.0/developers_guide_protocol_partial)

This enable client to manually select or deselect fields that they only need.

We can have code like this in our .jbuilder file

``` ruby
# @people = People.all
json.people @people, except: params[:except].split(',') do |person|
  json.id person.id
  json.name person.name
  json.email person.email
end

# localhost:3000/people?except=id,name
# => [ { "email": "foo@bar.com" }, { "email": "foo@baz.com" } ]
```

or

``` ruby
# @people = People.all
json.people @people, only: params[:fields].split(',') do |person|
  json.id person.id
  json.name person.name
  json.email person.email
end

# localhost:3000/people?fields=name,email
# => [ { "name": "foo bar", "email": "foo@bar.com" }, { "name": "foo baz", "email": "foo@baz.com" } ]
```
