### PR TITLE
Drop support for Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: ruby
 
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - ruby-head
   - ree
-  - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
   - rbx-19mode
 
 gemfile:
@@ -20,18 +17,11 @@ matrix:
   exclude:
     # Edge Rails is only compatible with 1.9.3+
     - gemfile: Gemfile.edge
-      rvm: 1.8.7
-    - gemfile: Gemfile.edge
       rvm: 1.9.2
     - gemfile: Gemfile.edge
       rvm: ree
-    - gemfile: Gemfile.edge
-      rvm: jruby-18mode
-    - gemfile: Gemfile.edge
-      rvm: rbx-18mode
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-18mode
     - rvm: rbx-19mode
 
 notifications:

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_dependency 'multi_json',    '>= 1.2.0'
 
+  s.required_ruby_version = '>= 1.9.0'
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
 end


### PR DESCRIPTION
- Don't run Travis CI for Ruby 1.8 versions
- Require Ruby >= 1.9.0 in gemspec
