### PR TITLE
nil-collection should be treated as empty array in template

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -92,7 +92,7 @@ class Jbuilder < JbuilderProxy
         # { "age": 32 }
         value
       end
-    elsif value.respond_to?(:map)
+    elsif value.respond_to?(:map) || ((opts = args.last).respond_to?(:map) && opts[:as])
       # json.comments @post.comments, :content, :created_at
       # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
       _scope{ array! value, *args }
@@ -221,7 +221,7 @@ class Jbuilder < JbuilderProxy
   #   json.array! [1, 2, 3]
   #
   #   [1,2,3]
-  def array!(collection, *attributes, &block)
+  def array!(collection = [], *attributes, &block)
     @attributes = if block && block.arity == 2
       _two_arguments_map_collection(collection, &block)
     elsif block

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -22,13 +22,15 @@ class JbuilderTemplate < Jbuilder
       options = { :partial => name_or_options, :locals => locals }
       as = locals.delete(:as)
       options[:as] = as if as.present?
-      options[:collection] = locals[:collection]
+      options[:collection] = locals[:collection] if locals.key?(:collection)
     end
+
+    options[:collection] ||= [] if options.key?(:collection)
 
     _handle_partial_options options
   end
 
-  def array!(collection, *attributes, &block)
+  def array!(collection = [], *attributes, &block)
     options = attributes.extract_options!
 
     if options.key?(:partial)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -110,12 +110,28 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_collection_rendered json
   end
 
+  test 'partial! renders as empty array for nil-collection' do
+    json = render_jbuilder <<-JBUILDER
+      json.partial! 'blog_post', :collection => nil, :as => :blog_post
+    JBUILDER
+
+    assert_equal '[]', json
+  end
+
   test 'partial! renders collection (alt. syntax)' do
     json = render_jbuilder <<-JBUILDER
       json.partial! :partial => 'blog_post', :collection => BLOG_POST_COLLECTION, :as => :blog_post
     JBUILDER
 
     assert_collection_rendered json
+  end
+
+  test 'partial! renders as empty array for nil-collection (alt. syntax)' do
+    json = render_jbuilder <<-JBUILDER
+      json.partial! :partial => 'blog_post', :collection => nil, :as => :blog_post
+    JBUILDER
+
+    assert_equal '[]', json
   end
 
   test 'render array of partials' do
@@ -126,12 +142,28 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_collection_rendered json
   end
 
+  test 'render array of partials as empty array with nil-collection' do
+    json = render_jbuilder <<-JBUILDER
+      json.array! nil, :partial => 'blog_post', :as => :blog_post
+    JBUILDER
+
+    assert_equal '[]', json
+  end
+
   test 'render array if partials as a value' do
     json = render_jbuilder <<-JBUILDER
       json.posts BLOG_POST_COLLECTION, :partial => 'blog_post', :as => :blog_post
     JBUILDER
 
     assert_collection_rendered json, 'posts'
+  end
+
+  test 'render as empty array if partials as a nil value' do
+    json = render_jbuilder <<-JBUILDER
+      json.posts nil, :partial => 'blog_post', :as => :blog_post
+    JBUILDER
+
+    assert_equal '{"posts":[]}', json
   end
 
   test 'fragment caching a JSON object' do


### PR DESCRIPTION
I noticed that when I passed in a nil as an empty collection in a template, it did not treat as an empty collection, although a nil-collection was already treated as an empty array in one place already in JBuilder:

``` ruby
json.array! @posts, partial: 'posts/post', as: :post
json.partial! 'posts/post', collection: @posts, as: :post
json.partial! partial: 'posts/post', collection: @posts, as: :post
json.comments @post.comments, partial: 'comment/comment', as: :comment
```

Without this change, if you were to have `json.array! @foos, partial: 'path/to/partial/foo', as: :foo` in index view and `json.(foo, ...)` in partial view, it would use the partial template that will return an error like the following, which is non-obvious; I had no idea that when the collection was nil it would still try to render the partial, so I thought it had to be something else:

```
NameError: undefined local variable or method `foo' for <<Class:0x007fc699c747c0>:0x007fc69a6e42f0>
app/views/path/to/partial/_foo.json.jbuilder:1:in `_app_views_path_to_partial__foo_json_jbuilder___82125411139652069_70245417019000'
app/views/path/to/view/index.json.jbuilder:1:in `_app_views_path_to_view_index_json_jbuilder__40707230780250694_70245416948080'
```

Instead of treating a nil collection as an empty array, it could raise `ArgumentError` or similar with a more specific error, but the following seems to go against that a little:
- `_map_collection` treating nil collection as array [here](https://github.com/rails/jbuilder/blob/7ff4d28c95162f4a9200c05722ae88101aa812bc/lib/jbuilder.rb#L312) and test [here](https://github.com/rails/jbuilder/blob/7ff4d28c95162f4a9200c05722ae88101aa812bc/test/jbuilder_test.rb#L206).
- `set!` (method_missing handling to allow json.\* calls in template) seeming to make an assumption [here](https://github.com/rails/jbuilder/blob/7ff4d28c95162f4a9200c05722ae88101aa812bc/lib/jbuilder.rb#L95) that something that doesn't respond to `map` is a single value and not array. So, I changed to look for `:as` option also.

Thanks for considering this change. We can work around it by having nil checks in each template, but I don't think that is as obvious.
