### PR TITLE
Pass options when calling cache_fragment_name

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -50,7 +50,7 @@ class JbuilderTemplate < Jbuilder
   #   end
   def cache!(key=nil, options={}, &block)
     if @context.controller.perform_caching
-      value = ::Rails.cache.fetch(_cache_key(key), options) do
+      value = ::Rails.cache.fetch(_cache_key(key, options), options) do
         _scope { yield self }
       end
 
@@ -83,11 +83,11 @@ class JbuilderTemplate < Jbuilder
       @context.render options
     end
 
-    def _cache_key(key)
+    def _cache_key(key, options)
       if @context.respond_to?(:cache_fragment_name)
         # Current compatibility, fragment_name_with_digest is private again and cache_fragment_name
         # should be used instead.
-        @context.cache_fragment_name(key)
+        @context.cache_fragment_name(key, options)
       elsif @context.respond_to?(:fragment_name_with_digest)
         # Backwards compatibility for period of time when fragment_name_with_digest was made public.
         @context.fragment_name_with_digest(key)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -228,6 +228,18 @@ class JbuilderTemplateTest < ActionView::TestCase
     JBUILDER
   end
 
+  test 'current cache digest option accepts options' do
+    undef_context_methods :fragment_name_with_digest
+
+    @context.expects(:cache_fragment_name).with('cachekey', skip_digest: true)
+
+    render_jbuilder <<-JBUILDER
+      json.cache! 'cachekey', skip_digest: true do
+        json.name 'Cache'
+      end
+    JBUILDER
+  end
+
   test 'does not perform caching when controller.perform_caching is false' do
     controller.perform_caching = false
     render_jbuilder <<-JBUILDER


### PR DESCRIPTION
This will allow `skip_digest` option to be used in `cache_fragment_name`. 
https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/cache_helper.rb#L154-L155
