### PR TITLE
Add cache_if! to conditionally cache JSON fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ json.cache! ['v1', @person], expires_in: 10.minutes do
 end
 ```
 
+You can also conditionally cache a block by using `cache_if!` like this:
+
+```ruby
+json.cache_if! !admin?, ['v1', @person], expires_in: 10.minutes do
+  json.extract! @person, :name, :age
+end
+```
+
 Keys can be auto formatted using `key_format!`, this can be used to convert keynames from the standard ruby_format to CamelCase:
 
 ``` ruby

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -60,6 +60,19 @@ class JbuilderTemplate < Jbuilder
     end
   end
 
+  # Conditionally catches the json depending in the condition given as first parameter. Has the same
+  # signature as the `cache` helper method in `ActionView::Helpers::CacheHelper` and so can be used in
+  # the same way.
+  #
+  # Example:
+  #
+  #   json.cache_if! !admin?, @person, expires_in: 10.minutes do
+  #     json.extract! @person, :name, :age
+  #   end
+  def cache_if!(condition, *args, &block)
+    condition ? cache!(*args, &block) : yield
+  end
+
   protected
     def _handle_partial_options(options)
       options.reverse_merge! locals: {}

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -185,6 +185,32 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal 'Cache', parsed['name']
   end
 
+  test 'conditionally fragment caching a JSON object' do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+
+    render_jbuilder <<-JBUILDER
+      json.cache_if! true, 'cachekey' do
+        json.test1 'Cache'
+      end
+      json.cache_if! false, 'cachekey' do
+        json.test2 'Cache'
+      end
+    JBUILDER
+
+    json = render_jbuilder <<-JBUILDER
+      json.cache_if! true, 'cachekey' do
+        json.test1 'Miss'
+      end
+      json.cache_if! false, 'cachekey' do
+        json.test2 'Miss'
+      end
+    JBUILDER
+
+    parsed = MultiJson.load(json)
+    assert_equal 'Cache', parsed['test1']
+    assert_equal 'Miss', parsed['test2']
+  end
+
   test 'fragment caching deserializes an array' do
     undef_context_methods :fragment_name_with_digest, :cache_fragment_name
 


### PR DESCRIPTION
I've found myself in the situation of needing this kinda often. Since Rails supports it, I think it should also be here for symmetry.
