### PR TITLE
Fix scoping issue

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -125,7 +125,7 @@ class JbuilderHandler
   def self.call(template)
     # this juggling is required to keep line numbers right in the error
     %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{template.source}
-      json.target! unless __already_defined}
+      json.target! unless (__already_defined && __already_defined != "method")}
   end
 end
 


### PR DESCRIPTION
If a "json" method is defined in a helper, defined?(json) returns
"method"; the json ||= ... assignment still happens because the variable
named "json" is not set. However, json.target! never gets called,
resulting in a blank jbuilder template
