### PR TITLE
Allow #merge! to accept Jbuilder objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ end
 # => [ { "name": "David", "age": 32 }, { "name": "Jamie", "age": 31 } ]
 ```
 
+You can merge Jbuilder objects within the array block
+
+``` ruby
+# @people = People.all
+json.array! @people do |person|
+  json.merge! people.to_builder
+end
+
+# => [ { "name": "David", "age": 32 }, { "name": "Jamie", "age": 31 } ]
+```
+
 You can also extract attributes from array directly.
 
 ``` ruby

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -275,7 +275,9 @@ class Jbuilder < JbuilderProxy
 
   # Merges hash or array into current builder.
   def merge!(hash_or_array)
-    if ::Array === hash_or_array
+    if ::Jbuilder === hash_or_array
+      merge!(hash_or_array.attributes!)
+    elsif ::Array === hash_or_array
       @attributes = [] unless ::Array === @attributes
       @attributes.concat hash_or_array
     else

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -312,6 +312,22 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal 'world', parsed.second['content']
   end
 
+  test 'top-level array merging with jbuilders' do
+    comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
+
+    json = Jbuilder.encode do |json|
+      json.array!(comments) do |comment|
+        json.merge!(Jbuilder.new do |json|
+          json.(comment, :content)
+        end)
+      end
+    end
+
+    parsed = MultiJson.load(json)
+    assert_equal 'hello', parsed.first['content']
+    assert_equal 'world', parsed.second['content']
+  end
+
   test 'extract attributes directly from array' do
     comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
 


### PR DESCRIPTION
The documentation didn't have any example on how to use jbuilders within an `#array!` block call, so after digging around the source code I realize that there's a `#merge!` method that I can use. This change makes the code cleaner when trying to use Jbuilder objects within the array! block.

Original code would look like:

``` ruby
json.array! @people do |person|
  json.merge! person.to_builder.attributes!
end
```

New code would look like:

``` ruby
json.array! @people do |person|
  json.merge! person.to_builder
end
```

I was tempted to not even include the `json.merge!` and have the block be smart about what object is returned, but I figure this is consistent with the rest of the API.
