### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ end
 
 If you are rendering fragments for a collection of objects, have a look at
 `jbuilder_cache_multi` gem. It uses fetch_multi (>= Rails 4.1) to fetch
-mutliple keys at once.
+multiple keys at once.
 
 Keys can be auto formatted using `key_format!`, this can be used to convert
 keynames from the standard ruby_format to camelCase:


### PR DESCRIPTION
`mutliple` -> `multiple`
