### PR TITLE
fix cache key generation for complex object

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -98,6 +98,13 @@ class JbuilderTemplate < Jbuilder
   end
 
   def _cache_key(key, options)
+    key = fragment_name_with_digest(key, options)
+    ::ActiveSupport::Cache.expand_cache_key(key.is_a?(::Hash) ? url_for(key).split('://').last : key, :jbuilder)
+  end
+
+  private
+
+  def fragment_name_with_digest(key, options)
     if @context.respond_to?(:cache_fragment_name)
       # Current compatibility, fragment_name_with_digest is private again and cache_fragment_name
       # should be used instead.
@@ -106,11 +113,9 @@ class JbuilderTemplate < Jbuilder
       # Backwards compatibility for period of time when fragment_name_with_digest was made public.
       @context.fragment_name_with_digest(key)
     else
-      ::ActiveSupport::Cache.expand_cache_key(key.is_a?(::Hash) ? url_for(key).split('://').last : key, :jbuilder)
+      key
     end
   end
-
-  private
 
   def _mapable_arguments?(value, *args)
     return true if super

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -246,6 +246,7 @@ class JbuilderTemplateTest < ActionView::TestCase
     undef_context_methods :fragment_name_with_digest
 
     @context.expects :cache_fragment_name
+    ActiveSupport::Cache.expects :expand_cache_key
 
     render_jbuilder <<-JBUILDER
       json.cache! 'cachekey' do
@@ -258,6 +259,7 @@ class JbuilderTemplateTest < ActionView::TestCase
     undef_context_methods :fragment_name_with_digest
 
     @context.expects(:cache_fragment_name).with('cachekey', skip_digest: true)
+    ActiveSupport::Cache.expects :expand_cache_key
 
     render_jbuilder <<-JBUILDER
       json.cache! 'cachekey', skip_digest: true do
@@ -275,18 +277,6 @@ class JbuilderTemplateTest < ActionView::TestCase
     JBUILDER
 
     assert_equal Rails.cache.inspect[/entries=(\d+)/, 1], '0'
-  end
-
-  test 'fragment caching falls back on ActiveSupport::Cache.expand_cache_key' do
-    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
-
-    ActiveSupport::Cache.expects :expand_cache_key
-
-    render_jbuilder <<-JBUILDER
-      json.cache! 'cachekey' do
-        json.name 'Cache'
-      end
-    JBUILDER
   end
 
 end


### PR DESCRIPTION
In Rails > 4, cache key would be expand fragment name with digest.

https://github.com/rails/rails/blob/4-0-stable/actionpack/lib/action_view/helpers/cache_helper.rb#L115
https://github.com/rails/rails/blob/4-0-stable/actionpack/lib/action_controller/caching/fragments.rb#L21-23

Without cache key expanding, following code would generate wrong cache key

``` ruby
json.cache! [current_user, current_user.issues] do #=> /user/1-20120806214154/<AR::Associations::CollectionProxy>/7a1156131a6928cb0026877f8b749ac9
  # blabla
end
```

With my patch, jbuilder can generate right cache key.
