### PR TITLE
Resolve error - ActionView::Template::Error (undefined method `update' for #<Object>)

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -21,7 +21,7 @@ class Jbuilder
     new(*args, &block).target!
   end
 
-  BLANK = ::Object.new
+  BLANK = ::Hash.new
 
   def set!(key, value = BLANK, *args, &block)
     result = if block


### PR DESCRIPTION
Hello,

Today I ran into a problem with Jbuilder after upgrading to version 2.2.1. I am rendering a fairly straightforward index view with nested fragment caching. In 2.1.3 I had no problem with this, but in 2.2.1 (also tested 2.2.0) I am seeing an error.

View (an oversimplified example):

``` ruby
json.cache! @widgets do
  json.array! @widgets do |widget|
    json.cache! widget do
      json.(widget, :id, :name)
    end
  end
end
```

Error log:

```
ActionView::Template::Error (undefined method `update' for #<Object:0x007fc94428a2e8>):
    1: json.cache! @widgets do
    2:   json.array! @widgets do |widget|
    3:     json.cache! widget do
    4:       json.(widget, :id, :name)
    5:     end
    6:   end
  app/views/widgets/index.json.jbuilder:3:in `block (2 levels) in _app_views_widgets_index_json_jbuilder___3796558778795566836_70251258071380'
  app/views/widgets/index.json.jbuilder:2:in `block in _app_views_widgets_index_json_jbuilder___3796558778795566836_70251258071380'
  app/views/widgets/index.json.jbuilder:1:in `_app_views_widgets_index_json_jbuilder___3796558778795566836_70251258071380'
  app/controllers/widgets_controller.rb:7:in `index'
```

I believe this is due to the fact that, prior to 2.2.x, the `attributes` variable [used to be an empty hash](https://github.com/rails/jbuilder/commit/81a63308fb9d5002519dd871f829ccc58067251a#diff-dfe2f2c088624955a66057cebf76a2e8L288) instead of an object. This commit restores the old behavior.
