### PR TITLE
Ensure dependency tracker loads after template handler

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -313,5 +313,4 @@ class Jbuilder
   end
 end
 
-require 'jbuilder/dependency_tracker'
 require 'jbuilder/railtie' if defined?(Rails)

--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -6,6 +6,7 @@ class Jbuilder
     initializer :jbuilder do |app|
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
+        require 'jbuilder/dependency_tracker'
       end
     end
 


### PR DESCRIPTION
As of this commit: https://github.com/rails/jbuilder/commit/c8acc5cea6da2a79b7b345adc301cb5ff2517647, Jbuilder has been requiring the dependency tracking module BEFORE registering the template handler for the `:jbuilder` extension.

Rails tries to associate handlers with dependency trackers, which fails if jbuilder is not registered to handle jbuilder files:

``` ruby
def self.register_tracker(extension, tracker)
  handler = Template.handler_for_extension(extension)
  @trackers[handler] = tracker
end
```

At the moment in time `dependency_tracker.rb` is currently required, `handler_for_extension(:jbuilder)` resolves to the default handler, `ERBHandler`. This causes Rails to set the default tracker for `ERBHandler` to Jbuilder's dependency tracker. This is _very bad_ because not only does it not work for digesting jbuilder dependencies, it also breaks digesting for normal erb views too.

I recommend an urgent merge and release.
