### PR TITLE
partial! + :locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ json.partial! partial: 'posts/post', collection: @posts, as: :post
 json.comments @post.comments, partial: 'comment/comment', as: :comment
 ```
 
+You can pass any objects into partial templates with or without `:locals` option.
+
+```ruby
+json.partial! 'sub_template', locals: {user: user}
+
+# or
+
+json.partial! 'sub_template', user: user
+```
+
+
 You can explicitly make Jbuilder object return null if you want:
 
 ``` ruby

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -20,8 +20,13 @@ class JbuilderTemplate < Jbuilder
       # partial! partial: 'name', foo: 'bar'
       options = name_or_options
     else
+      # partial! 'name', locals: {foo: 'bar'}
+      if locals.one? && (locals.keys.first == :locals)
+        options = locals.merge(partial: name_or_options)
+      else
+        options = { partial: name_or_options, locals: locals }
+      end
       # partial! 'name', foo: 'bar'
-      options = { partial: name_or_options, locals: locals }
       as = locals.delete(:as)
       options[:as] = as if as.present?
       options[:collection] = locals[:collection] if locals.key?(:collection)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -17,7 +17,7 @@ class JbuilderTemplate < Jbuilder
   def partial!(name_or_options, locals = {})
     case name_or_options
     when ::Hash
-      # partial! partial: 'name', locals: { foo: 'bar' }
+      # partial! partial: 'name', foo: 'bar'
       options = name_or_options
     else
       # partial! 'name', foo: 'bar'

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -110,6 +110,14 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal 'hello', MultiJson.load(json)['content']
   end
 
+  test 'partial! + locals via :locals option' do
+    json = render_jbuilder <<-JBUILDER
+      json.partial! 'partial', locals: {foo: 'howdy'}
+    JBUILDER
+
+    assert_equal 'howdy', MultiJson.load(json)['content']
+  end
+
   test 'partial! + locals without :locals key' do
     json = render_jbuilder <<-JBUILDER
       json.partial! 'partial', foo: 'goodbye'

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -40,7 +40,7 @@ class JbuilderTemplateTest < ActionView::TestCase
 
   def partials
     {
-      '_partial.json.jbuilder'  => 'json.content "hello"',
+      '_partial.json.jbuilder'  => 'foo ||= "hello"; json.content foo',
       '_blog_post.json.jbuilder' => BLOG_POST_PARTIAL,
       '_collection.json.jbuilder' => COLLECTION_PARTIAL
     }
@@ -108,6 +108,14 @@ class JbuilderTemplateTest < ActionView::TestCase
     JBUILDER
 
     assert_equal 'hello', MultiJson.load(json)['content']
+  end
+
+  test 'partial! + locals without :locals key' do
+    json = render_jbuilder <<-JBUILDER
+      json.partial! 'partial', foo: 'goodbye'
+    JBUILDER
+
+    assert_equal 'goodbye', MultiJson.load(json)['content']
   end
 
   test 'partial! renders collections' do


### PR DESCRIPTION
I was surprised to see that `partial!` doesn't handle `:locals` option in the same way as ActionView.

There was a comment in code that implies `partial! partial: 'name', locals: { foo: 'bar' }` would work, but in fact that code does not work, and does not even tested.

So here's an implementation with tests for:
`json.partial! 'partial_name', locals: {foo: 'bar}`
and
`json.partial! 'partial_name', foo: 'bar`
