### PR TITLE
Add #collect!

### DIFF
--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -208,6 +208,18 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal 'world', result['comments'].second['content']
   end
 
+  test 'nesting multiple children with collect block' do
+    result = jbuild do |json|
+      json.collect!(:comments) do
+        json.content 'hello'
+        json.content 'world'
+      end
+    end
+
+    assert_equal 'hello', result['comments'].first['content']
+    assert_equal 'world', result['comments'].second['content']
+  end
+
   test 'nesting single child with inline extract' do
     person = Person.new('David', 32)
 


### PR DESCRIPTION
This adds `#collect!(key)`, which is useful when you would want to build an array without knowing the inputs for it ahead of time. I'm using this for building Elasticsearch queries, like:

    Jbuilder.encode do |j|
      j.query { j.match_all }
      j.collect!(:filter) do
        j.range(a: {to: 3})  if condition?("a")
        j.range(b: {to: 5})  if condition?("b")
        j.range(c: {to: 10}) if condition?("c")
      end
    end

Rather than the less pleasant:

    Jbuilder.encode do |j|
      j.query { j.match_all }
      j.filter do
        j.child! { j.range(a: {to: 3})  } if condition?("a")
        j.child! { j.range(b: {to: 5})  } if condition?("b")
        j.child! { j.range(c: {to: 10}) } if condition?("c")
      end
    end

When collecting, each child clause is collected as its own sub-document into the parent array.