### PR TITLE
Add Blank#empty? to tell if attributes are empty or not

### DIFF
--- a/lib/jbuilder/blank.rb
+++ b/lib/jbuilder/blank.rb
@@ -3,5 +3,9 @@ class Jbuilder
     def ==(other)
       super || Blank === other
     end
+
+    def empty?
+      true
+    end
   end
 end

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -645,6 +645,29 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_nil result['author']
   end
 
+  test 'non-empty attributes' do
+    result = jbuild do |json|
+      json.fizz 'buzz'
+
+      if json.attributes!.empty?
+        json.foo 'bar'
+      end
+    end
+
+    assert !result.key?('foo')
+  end
+
+  test 'empty attributes' do
+    result = jbuild do |json|
+      if json.attributes!.empty?
+        json.foo 'bar'
+      end
+    end
+
+    assert result.key?('foo')
+    assert_equal 'bar', result['foo']
+  end
+
   test 'throws ArrayError when trying to add a key to an array' do
     assert_raise Jbuilder::ArrayError do
       jbuild do |json|


### PR DESCRIPTION
Before:

```ruby
json.foo do
  json.attributes!.empty? #=> false
end
````

After:

```ruby
json.foo do
  json.attributes!.empty? #=> true
end
````

In my case, I want to ensure creating an array like:

```ruby
json.foo do
  if some_condition?
    json.child! do
      # Build a hash
    end
  end

  # and other conditional child! calling....

  # Ensure creating array if no child! called above.
  if json.attributes!.empty?
    json.array! []
  end
end
```

This worked with v2.1.2, but not with v2.2.9 because  `json.attributes!` returns `Jbuilder::Blank` object if attributes are empty.