### PR TITLE
Why don't we generate jbuilder templates for Rails 5?

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -10,7 +10,7 @@ class Jbuilder
       end
     end
 
-    if Rails::VERSION::MAJOR == 4
+    if Rails::VERSION::MAJOR >= 4
       generators do |app|
         Rails::Generators.configure! app.config.generators
         Rails::Generators.hidden_namespaces.uniq!


### PR DESCRIPTION
The patch has no test, but I confirmed that it works on my local rails/master app.