### PR TITLE
[performance] set default KeyFormatter to nil

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -5,13 +5,13 @@ require 'jbuilder/errors'
 require 'multi_json'
 
 class Jbuilder
-  @@key_formatter = KeyFormatter.new
+  @@key_formatter = nil
   @@ignore_nil    = false
 
   def initialize(options = {})
     @attributes = {}
 
-    @key_formatter = options.fetch(:key_formatter){ @@key_formatter.clone }
+    @key_formatter = options.fetch(:key_formatter){ @@key_formatter ? @@key_formatter.clone : nil}
     @ignore_nil = options.fetch(:ignore_nil, @@ignore_nil)
 
     yield self if ::Kernel.block_given?
@@ -275,7 +275,7 @@ class Jbuilder
   end
 
   def _key(key)
-    @key_formatter.format(key)
+    @key_formatter ? @key_formatter.format(key) : key.to_s
   end
 
   def _set_value(key, value)


### PR DESCRIPTION
benchmark code
```
class TestKey
  def initialize(key_formatter)
    @key_formatter = key_formatter
  end

  def key1(key)
    @key_formatter ? @key_formatter.format(key) : key.to_s
  end

  def key2(key)
    @key_formatter.format(key)
  end
end


a = TestKey.new(nil)
b = TestKey.new(Jbuilder::KeyFormatter.new)

called = 10000000
Benchmark.benchmark do |x|
  keys = (1..100).map{|i| "key#{i}"}
  x.report("without formatter:")   { called.times{ a.key1(keys.sample) } }
  x.report("with formatter:")      { called.times{ b.key2(keys.sample) } }
end
```

result

```
without formatter:  1.910000   0.000000   1.910000 (  1.918297)
with formatter:  3.030000   0.010000   3.040000 (  3.047730)
```