### PR TITLE
Fix: Properly require ostruct

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -3,6 +3,7 @@ require 'jbuilder/blank'
 require 'jbuilder/key_formatter'
 require 'jbuilder/errors'
 require 'multi_json'
+require 'ostruct'
 
 class Jbuilder
   @@key_formatter = nil


### PR DESCRIPTION
This properly requires OpenStruct.

```
$ irb -Ilib
irb(main):001:0> require 'jbuilder'
NameError: uninitialized constant OpenStruct
	from /home/strzibny/projects/jbuilder/lib/jbuilder.rb:26:in `<class:Jbuilder>'
	from /home/strzibny/projects/jbuilder/lib/jbuilder.rb:7:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
	from (irb):1
	from /usr/bin/irb:11:in `<main>'
```