### PR TITLE
Fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@
 
 1.2.1
 -----
-* [Added explicit dependency for MultiJson](https://github.com/rails/jbuilder/commit/4d58eacb6cd613679fb243484ff73a79bbbff2d2
+* [Added explicit dependency for MultiJson](https://github.com/rails/jbuilder/commit/4d58eacb6cd613679fb243484ff73a79bbbff2d2)
 
 1.2.0
 -----


### PR DESCRIPTION
I fixed markdown typo in CHANGELOG

# Before

![2015-07-16 15 34 30](https://cloud.githubusercontent.com/assets/608755/8716878/4d5c8ff2-2bd0-11e5-81e6-6e41a372af6a.png)

# After

![2015-07-16 15 34 44](https://cloud.githubusercontent.com/assets/608755/8716881/53fd06f2-2bd0-11e5-97d6-1c0d4b6af077.png)
