### PR TITLE
Fixed 'Accessing mime types via constants' Deprecation

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -170,7 +170,7 @@ end
 
 class JbuilderHandler
   cattr_accessor :default_format
-  self.default_format = Mime::JSON
+  self.default_format = Mime::Type[:JSON]
 
   def self.call(template)
     # this juggling is required to keep line numbers right in the error


### PR DESCRIPTION
Getting this DEPRECATION WARNING message now:
```
DEPRECATION WARNING: Accessing mime types via constants is deprecated.  Please change:
  `Mime::JSON`
to:
  `Mime::Type[:JSON]`
. (called from <class:JbuilderHandler> at ..../.rvm/gems/ruby-2.2.3@ruby2.2.3-rails5.0/gems/
jbuilder-2.3.1/lib/jbuilder/jbuilder_template.rb:173)
```
so I changed the code (1 line) as specified above.

Then I changed my Gemfile on a different repo to:
```
gem 'jbuilder', git: 'git://github.com/jasnow/jbuilder.git', branch: 'fixmimijsondep'
```
and ran "bundle" and "rake" and now the DEPRECATION WARNING is gone.