### PR TITLE
[2nd try] Fixed 'Accessing mime types via constants' Deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gemfiles/*.lock
 Gemfile.lock
 .ruby-version
 pkg
+.rvmrc

--- a/Appraisals
+++ b/Appraisals
@@ -38,6 +38,9 @@ appraise "rails-4-2" do
 end
 
 appraise "rails-edge" do
-  gem "rails", github: "rails/rails"
-  gem "arel", github: "rails/arel"
+  gem "rails",            github: "rails/rails"
+  gem "arel",             github: "rails/arel"
+  gem "rack",             github: "rack/rack"
+  gem "sprockets",        github: "rails/sprockets"
+  gem 'sprockets-rails', "3.0.0.beta2"
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -8,5 +8,8 @@ gem "appraisal"
 gem "pry"
 gem "rails", :github => "rails/rails"
 gem "arel", :github => "rails/arel"
+gem "rack", :github => "rack/rack"
+gem "sprockets", :github => "rails/sprockets"
+gem "sprockets-rails", "3.0.0.beta2"
 
 gemspec :path => "../"

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -170,7 +170,7 @@ end
 
 class JbuilderHandler
   cattr_accessor :default_format
-  self.default_format = Mime::Type:JSON
+  self.default_format = Mime::Type[:JSON]
 
   def self.call(template)
     # this juggling is required to keep line numbers right in the error

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -170,7 +170,7 @@ end
 
 class JbuilderHandler
   cattr_accessor :default_format
-  self.default_format = Mime::Type[:JSON]
+  self.default_format = Mime::Type:JSON
 
   def self.call(template)
     # this juggling is required to keep line numbers right in the error

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -170,7 +170,11 @@ end
 
 class JbuilderHandler
   cattr_accessor :default_format
-  self.default_format = Mime::Type[:JSON]
+  if Rails::VERSION::MAJOR >= 5
+    self.default_format = Mime::Type[:JSON]
+  else
+     self.default_format = Mime::JSON
+  end
 
   def self.call(template)
     # this juggling is required to keep line numbers right in the error

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -170,7 +170,7 @@ end
 
 class JbuilderHandler
   cattr_accessor :default_format
-  self.default_format = Mime::JSON
+  self.default_format = Mime::Type[:JSON]
 
   def self.call(template)
     # this juggling is required to keep line numbers right in the error


### PR DESCRIPTION
**Fixed 'Accessing mime types via constants' Deprecation**

 * Getting below DEPRECATION WARNING message now so I added the code (4 lines) to lib/jbuilder/jbuilder_template.rb file to support both pre-5 and 5+ Rails versions of Mime::JSON.
```
DEPRECATION WARNING: Accessing mime types via constants is deprecated.  Please change:
  `Mime::JSON`
to:
  `Mime::Type[:JSON]`
. (called from <class:JbuilderHandler> at
..../.rvm/gems/ruby-2.2.3@ruby2.2.3-rails5.0/gems/
jbuilder-2.3.1/lib/jbuilder/jbuilder_template.rb:173)
``` 
 *  Also added 3 gems to "Appraisal" file for rails-edge so "appraisal install" and "appraisal rake test" work locally.
 * Then I watched Travis for my new version and saw that it was green.
https://travis-ci.org/jasnow/jbuilder/builds/82182056
 * Then I changed my "Gemfile" file in a sample Rails 5 app to use my new version and ran "bundle" and "rake" and now the DEPRECATION WARNING is gone.
```
gem 'jbuilder', git: 'git://github.com/jasnow/jbuilder.git', branch: 'fixmimijsondep'
```
 * Then I changed my "Gemfile" file in a sample Rails 4.2 app to use my new version and ran "bundle" and "rake" and I did not break the test run.
```
gem 'jbuilder', git: 'git://github.com/jasnow/jbuilder.git', branch: 'fixmimijsondep'
```
Welcome suggestions and improvements.