### PR TITLE
Add #extract_without_nil!

### DIFF
--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -99,6 +99,14 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal "hello", result["content"]
   end
 
+  test "extract_without_nil!" do
+    result = jbuild(<<-JBUILDER)
+      json.extract_without_nil! nil, :itself
+    JBUILDER
+
+    assert_equal false, result.key?("itself")
+  end
+
   test "key_format! with parameter" do
     result = jbuild(<<-JBUILDER)
       json.key_format! camelize: [:lower]


### PR DESCRIPTION
At @WellframeInc, we have a very outspoken member that advocates for not passing a key where the value is `null`. We couldn't actually find a consensus online as to what is the right convention. This PR adds the ability to specify `extract!` but to omit keys with `extract_without_nil!`.