### PR TITLE
merge! working with nested jbuilder object

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -268,7 +268,9 @@ class Jbuilder
   end
 
   def _merge_values(current_value, updates)
-    if _blank?(updates)
+    if ::Jbuilder === updates
+      ::Array === current_value ? current_value + updates.attributes! : updates.attributes!
+    elsif _blank?(updates)
       current_value
     elsif _blank?(current_value) || updates.nil?
       updates

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -418,6 +418,20 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
+  test 'nested jbuilder object via array!' do
+    to_nest = [
+      Jbuilder.new{ |json| json.nested_one '1st' },
+      Jbuilder.new{ |json| json.nested_two '2nd' }
+    ]
+
+    result = jbuild do |json|
+      json.array! to_nest
+    end
+
+    expected = [{'nested_one' => '1st'}, {'nested_two' => '2nd'}]
+    assert_equal expected, result
+  end
+
   test 'top-level array' do
     comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
 

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -391,6 +391,33 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
+  test 'nested jbuilder object via merge!' do
+    to_nest = Jbuilder.new{ |json| json.nested 'value' }
+
+    result = jbuild do |json|
+      json.merge! to_nest
+    end
+
+    expected = {'nested' => 'value'}
+    assert_equal expected, result
+  end
+
+  test 'nested jbuilder object via merge! in a block' do
+    to_nest = [
+      Jbuilder.new{ |json| json.nested_one '1st' },
+      Jbuilder.new{ |json| json.nested_two '2nd' }
+    ]
+
+    result = jbuild do |json|
+      json.nested to_nest do |builder|
+        json.merge! builder
+      end
+    end
+
+    expected = {'nested' => [{'nested_one' => '1st'}, {'nested_two' => '2nd'}]}
+    assert_equal expected, result
+  end
+
   test 'top-level array' do
     comments = [ Comment.new('hello', 1), Comment.new('world', 2) ]
 


### PR DESCRIPTION
...just like set! and the call syntax.

Hey there!

Here's the need: I like having "presenter" objects when implementing an API in order to separate interface and implementation - they all implement `to_builder`. I have an endpoint that renders a list of objects. Since JSON doesn't allow for top-level arrays, I end up writing template code like:

```
json.objects @objects do |object|
  json.merge! object.to_builder.attributes!
end
```

because `merge!` doesn't take a `Jbuilder` object.

This patch makes it possible to rewrite the previous code as:

```
json.objects @objects do |object|
  json.merge! object.to_builder
end
```

Not a big change, I think..
