### PR TITLE
Add soft_extrat! method to support unknown attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ json.author do
 end
 ```
 
+If you are expecting unknown attributes of object return null, use the `soft_extract!` method.
+``` ruby
+json.soft_extract! @post, :id, :title, :unknown_attr
+# => { "id" : 1, "title": "bar", "unknown_attr": null }
+```
+
 To prevent Jbuilder from including null values in the output, you can use the `ignore_nil!` method:
 
 ```ruby

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -288,7 +288,7 @@ class Jbuilder
   end
 
   def _extract_method_values_if_present(object, attributes)
-    attributes.each{ |key| _set_value key, object.try(key) }
+    attributes.each{ |key| _set_value key, object.public_send(key) if object.respond_to?(key) }
   end
 
   def _merge_block(key)

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -99,6 +99,18 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal 32, result['age']
   end
 
+  test 'soft extraction from object' do
+    person = Struct.new(:name, :age).new('David', 32)
+
+    result = jbuild do |json|
+      json.soft_extract! person, :name, :age, :unknown_method
+    end
+
+    assert_equal 'David', result['name']
+    assert_equal 32, result['age']
+    assert_equal nil, result['unknown_method']
+  end
+
   test 'extracting from object using call style for 1.9' do
     person = Struct.new(:name, :age).new('David', 32)
 
@@ -119,6 +131,18 @@ class JbuilderTest < ActiveSupport::TestCase
 
     assert_equal 'Jim', result['name']
     assert_equal 34, result['age']
+  end
+
+  test 'soft extracting from hash' do
+    person = {:name => 'Jim', :age => 34}
+
+    result = jbuild do |json|
+      json.soft_extract! person, :name, :age, :unknown_method
+    end
+
+    assert_equal 'Jim', result['name']
+    assert_equal 34, result['age']
+    assert_equal nil, result['unknown_method']
   end
 
   test 'nesting single child with block' do


### PR DESCRIPTION
  Return nil rather than raise error if attributes or hash elements are undefined.

``` ruby
@person = Struct.new(:name, :age).new('David', 32)

#   or you can utilize a Hash

@person = { name: 'David', age: 32 }

json.soft_extract! @person, :name, :age, :unknown
{ "name": "David", "age": 32, "unknown": nil }, { "name": "Jamie", "age": 31, "unknown": nil }
```
