### PR TITLE
Fix generation of broken controller on Rails 5.0 when ran w/o fields

### DIFF
--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -54,7 +54,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[<%= ":#{singular_table_name}" %>]
+      params.fetch(<%= ":#{singular_table_name}" %>, {})
       <%- else -%>
       params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -75,7 +75,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[<%= ":#{singular_table_name}" %>]
+      params.fetch(<%= ":#{singular_table_name}" %>, {})
       <%- else -%>
       params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/test/scaffold_api_controller_generator_test.rb
+++ b/test/scaffold_api_controller_generator_test.rb
@@ -42,5 +42,14 @@ if Rails::VERSION::MAJOR > 4
         assert_match(/params\.require\(:post\)\.permit\(:title, :body\)/, content)
       end
     end
+
+    test 'dont use require and permit if there are no attributes' do
+      run_generator %w(Post --api)
+
+      assert_file 'app/controllers/posts_controller.rb' do |content|
+        assert_match(/def post_params/, content)
+        assert_match(/params\.fetch\(:post, {}\)/, content)
+      end
+    end
   end
 end

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -54,4 +54,13 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/params\.require\(:post\)\.permit\(:title, :body\)/, content)
     end
   end
+
+  test 'dont use require and permit if there are no attributes' do
+    run_generator %w(Post)
+
+    assert_file 'app/controllers/posts_controller.rb' do |content|
+      assert_match(/def post_params/, content)
+      assert_match(/params\.fetch\(:post, {}\)/, content)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the issue reported on rails/rails#23314 that was already fixed on Rails default controller scaffold with PR rails/rails#22574

As stated on the Rails issue and PR, without this fix a newly generated controller will raise an `ArgumentError` on Rails 5.0:
```ruby
ArgumentError: When assigning attributes, you must pass a hash as an argument.
    app/controllers/carts_controller.rb:44:in `block in update'
    app/controllers/carts_controller.rb:43:in `update'
    test/controllers/carts_controller_test.rb:37:in `block in <class:CartsControllerTest>'
```

I believe that since it was changed on the Rails repo we should try to keep the same behaviour on JBuilder, as JBuilder is included by default with Rails and thus always overwrites the controller scaffold for new apps.