### PR TITLE
Cleanup: remove relic and confusing 'app' argument

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -3,7 +3,7 @@ require 'jbuilder/jbuilder_template'
 
 class Jbuilder
   class Railtie < ::Rails::Railtie
-    initializer :jbuilder do |app|
+    initializer :jbuilder do
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
         require 'jbuilder/dependency_tracker'


### PR DESCRIPTION
The `app` argument isn't used in the `#initializer` block. At a glance, especially because of so much nesting levels, it's confusing where the `app` argument is coming from on line 30 (`app.config.generators`). I didn't notice the other `app` coming in on line 29- thought line 30 was inside the block to `#initializer`.