### PR TITLE
Add fragment_cache_key support

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -104,8 +104,12 @@ class JbuilderTemplate < Jbuilder
 
   def _cache_key(key, options)
     key = _fragment_name_with_digest(key, options)
-    key = url_for(key).split('://', 2).last if ::Hash === key
-    ::ActiveSupport::Cache.expand_cache_key(key, :jbuilder)
+    if @context.respond_to?(:fragment_cache_key)
+      @context.fragment_cache_key(key)
+    else
+      key = url_for(key).split('://', 2).last if ::Hash === key
+      ::ActiveSupport::Cache.expand_cache_key(key, :jbuilder)
+    end
   end
 
   def _fragment_name_with_digest(key, options)


### PR DESCRIPTION
Jbuilder currently does not account for an app's [controller-wide `fragment_cache_key`s](https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/caching/fragments.rb#L31-L56). This change adds support when using a Rails version that implements `fragment_cache_key`.

I spent a couple hours trying to add a test, but couldn't wrangle one in to the current view-focused testing setup. Here's what I did to test and confirm the fix:

**1.** Created a fresh app with a minimal `Post` scaffolding and added a `json.cache!` block to the views
**2.** Piggybacked on Jbuilder in an initializer to log its cache keys
```ruby
# config/initializers/jbuilder.rb
require "jbuilder/jbuilder_template"

class JbuilderTemplate
  module CacheKeyLogging
    def _cache_key(key, options)
      super(key, options).tap { |result| ::Rails.logger.debug("Jbuilder _cache_key: #{result}") }
    end
  end

  prepend CacheKeyLogging
end
```
**3.** Added a `fragment_cache_key` call that *should* expire caches on each request
```ruby
class PostsController < ApplicationController
  fragment_cache_key { "time:#{Time.now.to_i}" }
  ...
end
```

Here's the logging output using jbuilder 2.5.0
```bash
$ rails s | egrep '(Started|Jbuilder)'
Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:21:14 -0400
Jbuilder _cache_key: jbuilder/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28

Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:21:17 -0400
Jbuilder _cache_key: jbuilder/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28

Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:21:19 -0400
Jbuilder _cache_key: jbuilder/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28
```

And here's the logging using this fork:
```bash
$ rails s | egrep '(Started|Jbuilder)'
Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:19:37 -0400
Jbuilder _cache_key: views/time:1465402777/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28

Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:19:40 -0400
Jbuilder _cache_key: views/time:1465402780/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28

Started GET "/posts.json" for 127.0.0.1 at 2016-06-08 12:19:42 -0400
Jbuilder _cache_key: views/time:1465402782/posts/1-20160608155128360573/21f64516528248e2de494b720ed1dc28
```

/cc @jeremy  @dhh 