### PR TITLE
Fix fragment_cache_key cache invalidation

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -104,7 +104,13 @@ class JbuilderTemplate < Jbuilder
 
   def _cache_key(key, options)
     key = _fragment_name_with_digest(key, options)
-    key = url_for(key).split('://', 2).last if ::Hash === key
+
+    if @context.respond_to?(:fragment_cache_key)
+      key = @context.fragment_cache_key(key)
+    else
+      key = url_for(key).split('://', 2).last if ::Hash === key
+    end
+
     ::ActiveSupport::Cache.expand_cache_key(key, :jbuilder)
   end
 

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -332,6 +332,35 @@ class JbuilderTemplateTest < ActionView::TestCase
     JBUILDER
   end
 
+  test "fragment caching uses fragment_cache_key" do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+
+    @context.expects(:fragment_cache_key).with("cachekey")
+
+    jbuild <<-JBUILDER
+      json.cache! "cachekey" do
+        json.name "Cache"
+      end
+    JBUILDER
+  end
+
+  test "fragment caching instrumentation" do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+
+    payloads = {}
+    ActiveSupport::Notifications.subscribe("read_fragment.action_controller") { |*args| payloads[:read_fragment] = args.last }
+    ActiveSupport::Notifications.subscribe("write_fragment.action_controller") { |*args| payloads[:write_fragment] = args.last }
+
+    jbuild <<-JBUILDER
+      json.cache! "cachekey" do
+        json.name "Cache"
+      end
+    JBUILDER
+
+    assert_equal "jbuilder/cachekey", payloads[:read_fragment][:key]
+    assert_equal "jbuilder/cachekey", payloads[:write_fragment][:key]
+  end
+
   test "current cache digest option accepts options" do
     undef_context_methods :fragment_name_with_digest
 


### PR DESCRIPTION
Jbuilder currently does not account for an app's [controller-wide `fragment_cache_key`s](https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/caching/fragments.rb#L31-L56) when computing its cache keys.

This change adds support, and also aligns Jbuilder's caching setup with [ActionView's cache helpers](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/cache_helper.rb#L219-L238) and [Abstract Controller's fragment caching and instrumentation](https://github.com/rails/rails/blob/52ce6ece8c8f74064bb64e0a0b1ddd83092718e1/actionpack/lib/abstract_controller/caching/fragments.rb#L72-L93).

To test, I made a fresh app with a `fragment_cache_key` call that *should* invalidate the template's cache with every request.
```ruby
# config/environments/development.rb
Rails.application.configure do
  config.x.counter = 0
  config.action_controller.perform_caching = true
  config.cache_store = :mem_cache_store
end

# app/controllers/widgets_controller.rb
class WidgetsController < ApplicationController
  before_action { Rails.application.config.x.counter += 1 }

  fragment_cache_key { Rails.application.config.x.counter }

  def index
  end
end

# app/views/widgets/index.json.jbuilder
json.cache! "unwavering-key" do
  json.config_x_counter Rails.application.config.x.counter
end
```

**Requests using Jbuilder 2.5.0**
```bash
$ curl http://0.0.0.0:3000/widgets.json
{"config_x_counter":1}

$ curl http://0.0.0.0:3000/widgets.json
{"config_x_counter":1} 
```
```log
Started GET "/widgets.json" for 127.0.0.1 at 2016-06-13 18:42:18 -0400
Processing by WidgetsController#index as JSON
  Rendering widgets/index.json.jbuilder
  Rendered widgets/index.json.jbuilder (5.7ms)
Completed 200 OK in 18ms (Views: 10.4ms | ActiveRecord: 0.0ms)

Started GET "/widgets.json" for 127.0.0.1 at 2016-06-13 18:42:20 -0400
Processing by WidgetsController#index as JSON
  Rendering widgets/index.json.jbuilder
  Rendered widgets/index.json.jbuilder (5.7ms)
Completed 200 OK in 10ms (Views: 8.7ms | ActiveRecord: 0.0ms)
```

**Requests using this branch**
```bash
$ curl http://0.0.0.0:3000/widgets.json
{"config_x_counter":1}

$ curl http://0.0.0.0:3000/widgets.json
{"config_x_counter":2}
```
```log
Processing by WidgetsController#index as JSON
  Rendering widgets/index.json.jbuilder
Read fragment jbuilder/views/1/unwavering-key/c9b8ffbaac0ab06acdab1ba36772a5dc (2.7ms)
Write fragment jbuilder/views/1/unwavering-key/c9b8ffbaac0ab06acdab1ba36772a5dc (0.5ms)
  Rendered widgets/index.json.jbuilder (6.5ms)
Completed 200 OK in 19ms (Views: 11.1ms | ActiveRecord: 0.0ms)

Started GET "/widgets.json" for 127.0.0.1 at 2016-06-13 18:39:53 -0400
Processing by WidgetsController#index as JSON
  Rendering widgets/index.json.jbuilder
Read fragment jbuilder/views/2/unwavering-key/c9b8ffbaac0ab06acdab1ba36772a5dc (0.5ms)
Write fragment jbuilder/views/2/unwavering-key/c9b8ffbaac0ab06acdab1ba36772a5dc (0.7ms)
  Rendered widgets/index.json.jbuilder (6.5ms)
Completed 200 OK in 11ms (Views: 9.5ms | ActiveRecord: 0.0ms)
```
Note that the cache was correctly invalidated _and_ the presence logging like you'd see when using `cache` in an .erb template.

/cc @jeremy 