### PR TITLE
DRY generated view files

### DIFF
--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -20,6 +20,7 @@ module Rails
           filename = filename_with_extensions(view)
           template filename, File.join('app/views', controller_file_path, filename)
         end
+        template filename_with_extensions('partial'), File.join('app/views', controller_file_path, filename_with_extensions("_#{singular_table_name}"))
       end
 
 

--- a/lib/generators/rails/templates/index.json.jbuilder
+++ b/lib/generators/rails/templates/index.json.jbuilder
@@ -1,4 +1,2 @@
-json.array!(@<%= plural_table_name %>) do |<%= singular_table_name %>|
-  json.extract! <%= singular_table_name %>, <%= attributes_list %>
-  json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)
-end
+json.array! @<%= plural_table_name %>, partial: '<%= plural_table_name %>/<%= singular_table_name %>', as: :<%= singular_table_name %>
+

--- a/lib/generators/rails/templates/index.json.jbuilder
+++ b/lib/generators/rails/templates/index.json.jbuilder
@@ -1,2 +1,1 @@
 json.array! @<%= plural_table_name %>, partial: '<%= plural_table_name %>/<%= singular_table_name %>', as: :<%= singular_table_name %>
-

--- a/lib/generators/rails/templates/partial.json.jbuilder
+++ b/lib/generators/rails/templates/partial.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! <%= singular_table_name %>, <%= attributes_list %>
+json.extract! <%= singular_table_name %>, <%= attributes_list_with_timestamps %>
 json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)

--- a/lib/generators/rails/templates/partial.json.jbuilder
+++ b/lib/generators/rails/templates/partial.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! <%= singular_table_name %>, <%= attributes_list %>
+json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)

--- a/lib/generators/rails/templates/show.json.jbuilder
+++ b/lib/generators/rails/templates/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @<%= singular_table_name %>, <%= attributes_list_with_timestamps %>
+json.partial! "<%= plural_table_name %>/<%= singular_table_name %>", <%= singular_table_name %>: @<%= singular_table_name %>

--- a/test/jbuilder_generator_test.rb
+++ b/test/jbuilder_generator_test.rb
@@ -14,19 +14,25 @@ class JbuilderGeneratorTest < Rails::Generators::TestCase
     %w(index show).each do |view|
       assert_file "app/views/posts/#{view}.json.jbuilder"
     end
+    assert_file "app/views/posts/_post.json.jbuilder"
   end
 
   test 'index content' do
     run_generator
 
     assert_file 'app/views/posts/index.json.jbuilder' do |content|
-      assert_match /json\.array!\(@posts\) do \|post\|/, content
-      assert_match /json\.extract! post, :id, :title, :body/, content
-      assert_match /json\.url post_url\(post, format: :json\)/, content
+      assert_match /json.array! @posts, partial: 'posts\/post', as: :post/, content
     end
 
     assert_file 'app/views/posts/show.json.jbuilder' do |content|
-      assert_match /json\.extract! @post, :id, :title, :body, :created_at, :updated_at/, content
+      assert_match /json.partial! \"posts\/post\", post: @post/, content
     end
+    
+    assert_file 'app/views/posts/_post.json.jbuilder' do |content|            
+      assert_match /json\.extract! post, :id, :title, :body/, content
+      assert_match /json\.url post_url\(post, format: :json\)/, content
+    end
+    
+
   end
 end


### PR DESCRIPTION
Currently when you generate a scaffold controller, the view files aren't DRY - this patch changes the behavior so that the generated files will look like this:

 app/views/posts/index.json.jbuilder:

```
json.array! @posts, partial: 'posts/post', as: :post
```

app/views/posts/show.json.jbuilder:
```
json.partial! "posts/post", post: @post
```

app/views/posts/_post.json.jbuilder:
```
json.extract! post, :id, :title, :body
json.url post_url(post, format: :json)
```