### PR TITLE
Avoid silently overwriting with merge

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -270,14 +270,14 @@ class Jbuilder
   def _merge_values(current_value, updates)
     if _blank?(updates)
       current_value
-    elsif _blank?(current_value) || updates.nil?
+    elsif _blank?(current_value) || updates.nil? || current_value.empty? && ::Array === updates
       updates
-    elsif ::Array === updates
-      ::Array === current_value ? current_value + updates : updates
-    elsif ::Hash === current_value
+    elsif ::Array === current_value && ::Array === updates
+      current_value + updates
+    elsif ::Hash === current_value && ::Hash === updates
       current_value.merge(updates)
     else
-      raise "Can't merge #{updates.inspect} with #{current_value.inspect}"
+      raise MergeError.build(current_value, updates)
     end
   end
 

--- a/lib/jbuilder/errors.rb
+++ b/lib/jbuilder/errors.rb
@@ -14,4 +14,11 @@ class Jbuilder
       new(message)
     end
   end
+
+  class MergeError < ::StandardError
+    def self.build(current_value, updates)
+      message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
+      new(message)
+    end
+  end
 end

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -686,4 +686,31 @@ class JbuilderTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "throws MergeError when trying to merge array with non-empty hash" do
+    assert_raise Jbuilder::MergeError do
+      jbuild do |json|
+        json.name "Daniel"
+        json.merge! []
+      end
+    end
+  end
+
+  test "throws MergeError when trying to merge hash with array" do
+    assert_raise Jbuilder::MergeError do
+      jbuild do |json|
+        json.array!
+        json.merge!({})
+      end
+    end
+  end
+
+  test "throws MergeError when trying to merge invalid objects" do
+    assert_raise Jbuilder::MergeError do
+      jbuild do |json|
+        json.name "Daniel"
+        json.merge! "Nope"
+      end
+    end
+  end
 end


### PR DESCRIPTION
At the moment `merge!` with an array will overwrite any existing hash
attributes. It should probably raise a `MergeError`. It also makes sense
to raise this error when attempting to merge a hash into an array, or
when trying to merge a non-hash-or-array.
