### PR TITLE
Fix typo/wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jbuilder
 
 Jbuilder gives you a simple DSL for declaring JSON structures that beats
-messaging giant hash structures. This is particularly helpful when the
+manipulating giant hash structures. This is particularly helpful when the
 generation process is fraught with conditionals and loops. Here's a simple
 example:
 


### PR DESCRIPTION
This was recently and erroneously (IMO) changed in 955acd4 / #366. This PR submits a third wording which is hopefully the best of all.

1. Originally: "massaging giant hash structures"
2. Then: "messaging giant hash structures"
3. Now (this PR): "manipulating giant hash structures"