### PR TITLE
Fix `:locals` option to always work with `:partial`.

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -161,7 +161,7 @@ class JbuilderTemplate < Jbuilder
     elsif _is_collection?(object)
       _scope{ _render_partial_with_options options.merge(collection: object) }
     else
-      locals = ::Hash[options[:as], object]
+      locals = options[:locals].to_h.merge(options[:as].to_sym => object)
       _scope{ _render_partial options.merge(locals: locals) }
     end
 

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -145,6 +145,14 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal "goodbye", result["content"]
   end
 
+  test "inline partial! + locals via :locals option" do
+    result = jbuild(<<-JBUILDER)
+      json.where_is 6, partial: "partial", locals: { foo: "pancakes house?" }, as: "partial"
+    JBUILDER
+
+    assert_equal "pancakes house?", result["where_is"]["content"]
+  end
+
   test "partial! renders collections" do
     result = jbuild(<<-JBUILDER)
       json.partial! "blog_post", collection: BLOG_POST_COLLECTION, as: :blog_post


### PR DESCRIPTION
The `:locals` option doesn't always work with `:partial`. If you say:

    json.x some_non_collection_value, partial: p, locals: { ... }

then the `:locals` option is ignored. If you say:

    json.x some_collection_value, partial: p, locals: { y: z }

then the `:locals` make it through to the partial. The more explicit (but less pretty):

    json.x do
      json.partial! p, locals: { y: z }
    end

version works fine. This seems inconsistent to me and having to use the `json.x { json.partial! ... }` form is less readable and overly verbose.

This one-line change makes `:locals` work properly in the

    json.x some_non_collection_value, partial: ...

case.

---

The `to_sym` call in:

    locals = options[:locals].to_h.merge(options[:as].to_sym => object)

is needed for the `"inline partial! + locals via :locals option"` test to pass when:

 1. You're outside Rails3.X
 2. The `:as` option has a string rather than a symbol as its value.

The break occurs deep inside ActionPack where it tries to compare a string and a symbol using `<=>`.

The `"fragment caching works with previous version of cache digests"` test breaks for me out of the box except with Rails3.X. That is not related to my issue and happens with a fresh clone so I ignored it.