### PR TITLE
Set proper type for jbuilder option to prevent a warning

### DIFF
--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -6,7 +6,7 @@ module Rails
     class ScaffoldControllerGenerator
       source_paths << File.expand_path('../templates', __FILE__)
 
-      hook_for :jbuilder, default: true
+      hook_for :jbuilder, type: :boolean, default: true
     end
   end
 end


### PR DESCRIPTION
Right now `rails g scaffold_controller` w/ rails-5.0.0.1 produces a warning
>Expected string default value for '--jbuilder'; got true (boolean)