### PR TITLE
Remove a Ruby warning that comes from lib/jbuilder/jbuilder_template.rb

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -11,6 +11,7 @@ class JbuilderTemplate < Jbuilder
 
   def initialize(context, *args)
     @context = context
+    @cached_root = nil
     super(*args)
   end
 


### PR DESCRIPTION
This commit removes the following Ruby warning:

```
lib/jbuilder/jbuilder_template.rb:80: warning: instance variable @cached_root not initialized
```