### PR TITLE
Test suite update to deal with new version of mocha

### DIFF
--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -6,8 +6,8 @@ gem "rake"
 gem "mocha", :require => false
 gem "appraisal"
 gem "pry"
-gem "railties", ">= 5.0.0.beta2", "< 5.1"
-gem "actionpack", ">= 5.0.0.beta2", "< 5.1"
-gem "activemodel", ">= 5.0.0.beta2", "< 5.1"
+gem "railties", "~> 5.0.0"
+gem "actionpack", "~> 5.0.0"
+gem "activemodel", "~> 5.0.0"
 
 gemspec :path => "../"

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -307,18 +307,6 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal %w[a b c], result
   end
 
-  test "fragment caching works with previous version of cache digests" do
-    undef_context_methods :cache_fragment_name
-
-    @context.expects :fragment_name_with_digest
-
-    jbuild <<-JBUILDER
-      json.cache! "cachekey" do
-        json.name "Cache"
-      end
-    JBUILDER
-  end
-
   test "fragment caching works with current cache digests" do
     undef_context_methods :fragment_name_with_digest
 


### PR DESCRIPTION
TL;DR A dependency (Mocha) fixed the behaviour of `method_exists?`. Before this fix the tests all passed. We believe this fix to correct the behaviour and that this is on us to now fix in jbuilder. The failing test cases were introduced before the various rails version appraisals and we think they can be removed as the range of appraisals make them redundant.

CI builds are currently failing and we are proposing a fix. Explanation is below.

The error:

```
1) Failure:
JbuilderTemplateTest#test_fragment_caching_works_with_previous_version_of_cache_digests [/Users/elena/Projects/OSS/jbuilder/test/jbuilder_template_test.rb:313]:
not all expectations were satisfied
unsatisfied expectations:
- expected exactly once, not yet invoked: #<JbuilderTemplateTest:0x7f8180d54180>.fragment_name_with_digest(any_parameters)

98 tests, 229 assertions, 1 failures, 0 errors, 0 skips
```

The source of the failure is: 

```
  jbuilder_test_template.rb#310

  test "fragment caching works with previous version of cache digests" do
    undef_context_methods :cache_fragment_name

    @context.expects :fragment_name_with_digest

    jbuild <<-JBUILDER
      json.cache! "cachekey" do
        json.name "Cache"
      end
    JBUILDER
  end
```

The test is failing for rails 4.0 and up. Looking at the commit where CI started reporting this as a breaking test, it's not clearly obvious why this would happen, since that commit is actually just a README update (CI is now turned off so I can't link to the exact commit where the tests started to fail).

The line in the test which breaks is `@context.expects :fragment_name_with_digest`. The `fragment_name_with_digest` method has become a private method and has been replaced in rails 4 and up by `cache_fragment_name`. This is the code that handles backwards compatibility in `jbuilder_template.rb` for `fragment_name_with_digest`:

```
  def _fragment_name_with_digest(key, options)
    if @context.respond_to?(:cache_fragment_name)
      # Current compatibility, fragment_name_with_digest is private again and cache_fragment_name
      # should be used instead.
      @context.cache_fragment_name(key, options)
    elsif @context.respond_to?(:fragment_name_with_digest)
      # Backwards compatibility for period of time when fragment_name_with_digest was made public.
      @context.fragment_name_with_digest(key)
    else
      key
    end
  end
``` 

This checks whether the `cache_fragment_name method` is defined. If not, then it falls back to `fragment_name_with_digest`.  

The actual reason why CI is failing is a dependency issue relating to the `mocha` gem being upgraded from version `1.1.0` to version `1.2.0` (and in the latest version, which is now `1.2.1`).

This is the commit in mocha where jbuilder starts to fail: https://github.com/freerange/mocha/commit/e87c03b068efc48267fbcd5a295514077c52b901 

In that commit, `method_exists?` has been replaced with `method_visibility`: 

```
  def method_exists?(method)
      symbol = method.to_sym
      __metaclass__ = stubbee.__metaclass__
      __metaclass__.public_method_defined?(symbol) ||
      __metaclass__.protected_method_defined?(symbol) ||
      __metaclass__.private_method_defined?(symbol)
  end
```

```
  def method_visibility(method)
      symbol = method.to_sym
      __metaclass__ = stubbee.__metaclass__

      (__metaclass__.public_method_defined?(symbol) && :public) ||
        (__metaclass__.protected_method_defined?(symbol) && :protected) ||
        (__metaclass__.private_method_defined?(symbol) && :private)
  end
```   

The new method is now removing `fragment_name_with_digest` in rails v4.0 and above (when it became a private method in rails). 

For reference, this is the full list of commits made between version `1.1.0` and version `1.2.0`: https://github.com/freerange/mocha/compare/v1.1.0...v1.2.0

If you revert mocha to the commit before the one above:

gem "mocha", git: 'https://github.com/freerange/mocha', ref: '6442acf'

And then do:

bundle install
appraisal install
appraisal rake test

All tests will pass. 

If we put a pry in the failing test, we see that for the passing commit:

`@context.respond_to?(:cache_fragment_name)` returns `false` 
`@context.respond_to?(:fragment_name_with_digest)` returns `true`

If we switch to the failing commit on mocha:  

gem "mocha", git: 'https://github.com/freerange/mocha', ref: 'e87c03b'

We can see that:

`@context.respond_to?(:cache_fragment_name)` returns `false` 
`@context.respond_to?(:fragment_name_with_digest)` returns `false`

The `@context.respond_to?(:fragment_name_with_digest)` now returns false for versions of rails 4 and up, because the method becomes private and is removed in mocha. 

The failing test will no longer be able to check for the existence of the `fragment_name_with_digest` and can be removed. 

**Our reasoning for this is the following:** 

It seems like the new behavior introduced by mocha is actually the correct one, since the fragment_name_with_digest method should not be present in versions of rails 4+.

Appraisal is being used to test that caching works with different versions of rails, so there's no need for this test to continue being used. 

At the same time, it could be argued that the test is being used to test implementation instead of behaviour. 