### PR TITLE
Fix Illformed requirement from e77e55df09

### DIFF
--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'activesupport', '>= 3.0.0'
-  s.add_dependency 'multi_json',    '=> 1.2'
+  s.add_dependency 'multi_json',    '>= 1.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
Otherwise you get this error after e77e55df09 by @dhh 
```
[!] There was an error parsing `Gemfile`:
[!] There was an error while loading `jbuilder.gemspec`: Illformed requirement ["=> 1.2"]. Bundler cannot continue.

 #  from ~/code/jbuilder/jbuilder.gemspec:13
 #  -------------------------------------------
 #    s.add_dependency 'activesupport', '>= 3.0.0'
 >    s.add_dependency 'multi_json',    '=> 1.2'
 #
 #  -------------------------------------------
. Bundler cannot continue.

 #  from ~/code/jbuilder/Gemfile:3
 #  -------------------------------------------
 #
 >  gemspec
 #
 #  -------------------------------------------
```