### PR TITLE
Fix implicitly rendering a JSON partial with the same name as an HTML partial

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -188,7 +188,7 @@ class JbuilderTemplate < Jbuilder
       _scope{ _render_partial_with_options options.merge(collection: object) }
     else
       locals = ::Hash[options[:as], object]
-      _scope{ _render_partial options.merge(locals: locals) }
+      _scope{ _render_partial_with_options options.merge(locals: locals) }
     end
 
     set! name, value


### PR DESCRIPTION
Assume two non-empty partials, one at `posts/_post.json.jbuilder` and the other at `posts/_post.html.erb`.

The following Jbuilder template unexpectedly results in an empty JSON object:

```ruby
jbuilder.post @post, partial: "posts/post", as: :post
```

This happens because, deep inside Jbuilder, `ActionView::Base#render` is called without the `:handlers` option. Action View finds all partial templates named `posts/post` and uses the first match, which may be an ERB template.

To fix, change `JbuilderTemplate#_set_inline_partial` to call `_render_partial_with_options` when given a singular object, as it would for a collection. This ensures that `ActionView::Base#render` is called with the necessary template lookup options.

Unfortunately, `ActionView::Base#render` doesn’t respect the `:handlers` option in Rails versions older than 4.0.0, so it’s not possible to fix this for Rails 3, which Jbuilder currently supports.

/cc @jeremy