### PR TITLE
Remove newly-unsupported Rails versions from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ rvm:
   - rbx
 
 gemfile:
-  - gemfiles/rails_3_0.gemfile
-  - gemfiles/rails_3_1.gemfile
-  - gemfiles/rails_3_2.gemfile
-  - gemfiles/rails_4_0.gemfile
-  - gemfiles/rails_4_1.gemfile
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
@@ -51,16 +46,6 @@ matrix:
       gemfile: gemfiles/rails_5_0.gemfile
     - rvm: rbx
       gemfile: gemfiles/rails_5_1.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails_3_0.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails_3_1.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails_3_2.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails_4_0.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails_4_1.gemfile
 
 notifications:
   email: false


### PR DESCRIPTION
As of eb5d376, 4.2 is the oldest supported version of Rails. Remove 3.x, 4.0, and 4.1 from the test matrix to fix CI.