### PR TITLE
Use a compatible version of Nokogiri to test against Rails 4.2

### DIFF
--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -9,5 +9,6 @@ gem "pry"
 gem "railties", "~> 4.2.0"
 gem "actionpack", "~> 4.2.0"
 gem "activemodel", "~> 4.2.0"
+gem "nokogiri", "~> 1.6.8"
 
 gemspec path: "../"


### PR DESCRIPTION
Nokogiri 1.7.0 dropped support for versions of Ruby older than 2.1.0, causing CI test failures for Rails 4.2 on Ruby 1.9.3 and 2.0.0. Stick to Nokogiri’s 1.6 release line, which maintains compatibility with Ruby 1.9.3 and newer.