### PR TITLE
make sure ActionView::Rendering is included in ActionController::API

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -10,16 +10,11 @@ class Jbuilder
       end
 
       if Rails::VERSION::MAJOR >= 5
-        module ::ActionController
-          module ApiRendering
-            include ActionView::Rendering
-          end
-        end
-
         ActiveSupport.on_load :action_controller do
           if self == ActionController::API
             include ActionController::Helpers
             include ActionController::ImplicitRender
+            include ActionView::Rendering
           end
         end
       end

--- a/test/jbuilder_railtie_test.rb
+++ b/test/jbuilder_railtie_test.rb
@@ -1,0 +1,17 @@
+require "action_controller"
+require "action_controller/railtie"
+require "action_view"
+require "jbuilder/railtie"
+require "rails"
+
+class JbuilderRailtieTest < ActiveSupport::TestCase
+  if Rails::VERSION::MAJOR >= 5
+    test 'ActionView::Rendering is included in ActionController::API after initialization' do
+      assert_equal false, ActionController::API.include?(ActionView::Rendering)
+
+      Jbuilder::Railtie.run_initializers
+      
+      assert_equal true, ActionController::API.include?(ActionView::Rendering)
+    end
+  end
+end


### PR DESCRIPTION
per #405  , this patch should fix rendering issues I and others have been having in Rails 5+

I'm not sure how to reproduce the issue, as it probably requires loading a dummy app and there could be dependencies or configurations that are causing it.

But I wrote a regression test to check that it works, and it works in the app that has been causing me problems. You can break the test by commenting out `include ActionView::Rendering` in `jbuilder/railtie.rb`