### PR TITLE
Switch from MultiJson to the inbuilt JSON library

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,21 +243,6 @@ environment.rb for example):
 Jbuilder.key_format camelize: :lower
 ```
 
-Faster JSON backends
---------------------
-
-Jbuilder uses MultiJson, which by default will use the JSON gem. That gem is
-currently tangled with ActiveSupport's all-Ruby `#to_json` implementation,
-which is slow (fixed in Rails >= 4.1). For faster Jbuilder rendering, you can
-specify something like the Yajl JSON generator instead. You'll need to include
-the `yajl-ruby` gem in your Gemfile and then set the following configuration
-for MultiJson:
-
-``` ruby
-require 'multi_json'
-MultiJson.use :yajl
- ```
-
 ## Contributing to Jbuilder
 
 Jbuilder is the work of many contributors. You're encouraged to submit pull requests, propose

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'activesupport', '>= 4.2.0'
-  s.add_dependency 'multi_json',    '>= 1.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -2,7 +2,6 @@ require 'jbuilder/jbuilder'
 require 'jbuilder/blank'
 require 'jbuilder/key_formatter'
 require 'jbuilder/errors'
-require 'multi_json'
 require 'ostruct'
 
 class Jbuilder
@@ -247,7 +246,7 @@ class Jbuilder
 
   # Encodes the current builder as JSON.
   def target!
-    ::MultiJson.dump(@attributes)
+    ::JSON.dump(@attributes)
   end
 
   private

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -70,7 +70,7 @@ class JbuilderTemplateTest < ActionView::TestCase
     lookup_context.view_paths = [resolver]
     template = ActionView::Template.new(source, "test", JbuilderHandler, virtual_path: "test")
     json = template.render(self, {}).strip
-    MultiJson.load(json)
+    JSON.load(json)
   end
 
   def undef_context_methods(*names)


### PR DESCRIPTION
Ruby comes with a JSON library since Ruby 1.9, which makes MultiJson
unneccessary. The usecase mentioned in the README only applies to Rails
4.1 or lower, which is no longer supported by Jbuilder.