### PR TITLE
Drop MultiJson dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+Unreleased
+-----
+
+* Drop the MultiJson dependency
+
 2.6.4
 -----
 

--- a/README.md
+++ b/README.md
@@ -246,17 +246,22 @@ Jbuilder.key_format camelize: :lower
 Faster JSON backends
 --------------------
 
-Jbuilder uses MultiJson, which by default will use the JSON gem. That gem is
-currently tangled with ActiveSupport's all-Ruby `#to_json` implementation,
-which is slow (fixed in Rails >= 4.1). For faster Jbuilder rendering, you can
-specify something like the Yajl JSON generator instead. You'll need to include
-the `yajl-ruby` gem in your Gemfile and then set the following configuration
-for MultiJson:
+Jbuilder depends on `ActiveSupport::JSON::Encoding`, which uses the stdlib's
+`json` gem by default. If you wish to use a third-party JSON implementation
+for faster encoding, you can do so by replacing the default encoder. For
+example, in order to use the [oj](https://github.com/ohler55/oj) gem, require
+the gem and call the `#optimize_rails` method in your application
+initializer:
 
-``` ruby
-require 'multi_json'
-MultiJson.use :yajl
- ```
+```ruby
+require 'oj'
+
+Oj.optimize_rails
+```
+
+This will inject Oj's JSON encoder into `ActiveSupport::JSON::Encoding`
+without breaking compatibility (with a few exceptions). For more details
+about Oj's Rails mode, please refer to [their official documentation](https://github.com/ohler55/oj/blob/master/pages/Rails.md#oj-rails-compatibility).
 
 ## Contributing to Jbuilder
 

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'activesupport', '>= 4.2.0'
-  s.add_dependency 'multi_json',    '>= 1.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -2,7 +2,7 @@ require 'jbuilder/jbuilder'
 require 'jbuilder/blank'
 require 'jbuilder/key_formatter'
 require 'jbuilder/errors'
-require 'multi_json'
+require 'active_support/json'
 require 'ostruct'
 
 class Jbuilder
@@ -247,7 +247,7 @@ class Jbuilder
 
   # Encodes the current builder as JSON.
   def target!
-    ::MultiJson.dump(@attributes)
+    ::ActiveSupport::JSON.encode(@attributes)
   end
 
   private

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -70,7 +70,7 @@ class JbuilderTemplateTest < ActionView::TestCase
     lookup_context.view_paths = [resolver]
     template = ActionView::Template.new(source, "test", JbuilderHandler, virtual_path: "test")
     json = template.render(self, {}).strip
-    MultiJson.load(json)
+    ActiveSupport::JSON.decode(json)
   end
 
   def undef_context_methods(*names)


### PR DESCRIPTION
Back in the day, the MultiJson dependency was introduced to add the ability to inject a faster JSON implementation. Time has passed,  and today Jbuilder only has support for Rails 4.2 and older, all major Rubies ship with the `json` gem as stdlib, and Oj 3.0 even provides [Rails mode](https://github.com/ohler55/oj/blob/master/pages/Rails.md#oj-rails-compatibility).

I think it's time to drop the MultiJson dependency and just use `ActiveSupport::JSON::Encoding`. If the user wants to replace the default encoder, they should be responsible for doing so (example for Oj added to the README), and third-party gems should be responsible for ensuring the compatibility with `ActiveSupport::JSON` (which Oj does really well).