### PR TITLE
add :force option to cache!

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Fragment caching is supported, it uses `Rails.cache` and works like caching in
 HTML templates:
 
 ```ruby
-json.cache! ['v1', @person], expires_in: 10.minutes do
+json.cache! ['v1', @person], expires_in: 10.minutes, force: true do
   json.extract! @person, :name, :age
 end
 ```

--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_RETRY: "1"

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -130,7 +130,8 @@ class JbuilderTemplate < Jbuilder
 
   def _cache_fragment_for(key, options, &block)
     key = _cache_key(key, options)
-    _read_fragment_cache(key, options) || _write_fragment_cache(key, options, &block)
+    force = options[:force].present?
+    (!force && _read_fragment_cache(key, options)) || _write_fragment_cache(key, options, &block)
   end
 
   def _read_fragment_cache(key, options = nil)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -289,6 +289,37 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal "Miss", result["test2"]
   end
 
+  test "fragment caching a JSON object with force option" do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+
+    jbuild <<-JBUILDER
+      json.cache! "cachekey" do
+        json.test1 "Value"
+      end
+    JBUILDER
+
+    result = jbuild(<<-JBUILDER)
+      json.cache! "cachekey", force: false do
+        json.test1 "New Value"
+      end
+    JBUILDER
+    assert_equal "Value", result["test1"]
+
+    result = jbuild(<<-JBUILDER)
+      json.cache! "cachekey", force: true do
+        json.test1 "New Value"
+      end
+    JBUILDER
+    assert_equal "New Value", result["test1"]
+    result = jbuild(<<-JBUILDER)
+      json.cache! "cachekey" do
+        json.test1 "Cache Miss"
+      end
+    JBUILDER
+    assert_equal "New Value", result["test1"]
+    puts result
+  end
+
   test "fragment caching deserializes an array" do
     undef_context_methods :fragment_name_with_digest, :cache_fragment_name
 


### PR DESCRIPTION
Before change https://github.com/rails/jbuilder/commit/65dfb3305b1c1ebae550c420a6ab6bd0e21271ec you could pass the :force option to cache! This worked because cache! used Rails.cache.fetch which takes the force option. That commit rewrote cache to use Rails.cache.read and Rails.cache.write which don't do anything with the force option. I use :force extensively in my jbuilder template to send a parameter that will clear and write the cache for the next request. I think this is a worthy feature to have even if it was an undocumented and unintentional feature of jbuilder pre-2.6.0
Closes #424 
