### PR TITLE
Replace deprecated fragment_cache_key for Rails 5.2 support

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -151,8 +151,8 @@ class JbuilderTemplate < Jbuilder
     name_options = options.slice(:skip_digest, :virtual_path)
     key = _fragment_name_with_digest(key, name_options)
 
-    if @context.respond_to?(:fragment_cache_key)
-      key = @context.fragment_cache_key(key)
+    if @context.respond_to?(:combined_fragment_cache_key)
+      key = @context.combined_fragment_cache_key(key)
     else
       key = url_for(key).split('://', 2).last if ::Hash === key
     end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -320,10 +320,10 @@ class JbuilderTemplateTest < ActionView::TestCase
     JBUILDER
   end
 
-  test "fragment caching uses fragment_cache_key" do
+  test "fragment caching uses combined_fragment_cache_key" do
     undef_context_methods :fragment_name_with_digest, :cache_fragment_name
 
-    @context.expects(:fragment_cache_key).with("cachekey")
+    @context.expects(:combined_fragment_cache_key).with("cachekey")
 
     jbuild <<-JBUILDER
       json.cache! "cachekey" do


### PR DESCRIPTION
`fragment_cache_key` has been deprecated in Rails 5.2.  Every call to `json.cache!` results in the following message:

```
DEPRECATION WARNING: Calling fragment_cache_key directly is deprecated and will be
removed in Rails 6.0. All fragment accessors now use the combined_fragment_cache_key
method that retains the key as an array, such that the caching stores can interrogate
the parts for cache versions used in recyclable cache keys.
```

Replacing calls to `fragment_cache_key` with `combined_fragment_cache_key` fixes the deprecation issue.  Related to #427.