### PR TITLE
Fix passing object with partials w/o locals (#378).

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -104,7 +104,7 @@ class JbuilderTemplate < Jbuilder
   private
 
   def _render_partial_with_options(options)
-    options.reverse_merge! locals: {}
+    options.reverse_merge! locals: options.except(:partial, :as, :collection)
     options.reverse_merge! ::JbuilderTemplate.template_lookup_options
     as = options[:as]
 
@@ -199,7 +199,6 @@ class JbuilderTemplate < Jbuilder
     when ::Hash
       # partial! partial: 'name', foo: 'bar'
       options = name_or_options
-      options[:locals] ||= options.except(:partial, :as, :collection)
     else
       # partial! 'name', locals: {foo: 'bar'}
       if locals.one? && (locals.keys.first == :locals)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -111,8 +111,9 @@ class JbuilderTemplate < Jbuilder
     if as && options.key?(:collection)
       as = as.to_sym
       collection = options.delete(:collection)
+      locals = options.delete(:locals) || {}
       array! collection do |member|
-        member_locals = options.clone
+        member_locals = options.clone.merge(locals)
         member_locals.merge! collection: collection
         member_locals.merge! as => member
         _render_partial options.merge(locals: member_locals)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -111,9 +111,9 @@ class JbuilderTemplate < Jbuilder
     if as && options.key?(:collection)
       as = as.to_sym
       collection = options.delete(:collection)
-      locals = options.delete(:locals) || {}
+      locals = options.delete(:locals)
       array! collection do |member|
-        member_locals = options.clone.merge(locals)
+        member_locals = locals.clone
         member_locals.merge! collection: collection
         member_locals.merge! as => member
         _render_partial options.merge(locals: member_locals)
@@ -199,6 +199,7 @@ class JbuilderTemplate < Jbuilder
     when ::Hash
       # partial! partial: 'name', foo: 'bar'
       options = name_or_options
+      options[:locals] ||= options.except(:partial, :as, :collection)
     else
       # partial! 'name', locals: {foo: 'bar'}
       if locals.one? && (locals.keys.first == :locals)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -111,9 +111,8 @@ class JbuilderTemplate < Jbuilder
     if as && options.key?(:collection)
       as = as.to_sym
       collection = options.delete(:collection)
-      locals = options.delete(:locals)
       array! collection do |member|
-        member_locals = locals.clone
+        member_locals = options.clone
         member_locals.merge! collection: collection
         member_locals.merge! as => member
         _render_partial options.merge(locals: member_locals)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -15,6 +15,16 @@ BLOG_POST_PARTIAL = <<-JBUILDER
   end
 JBUILDER
 
+BLOG_POST_PARTIAL_WITH_LOCALS = <<-JBUILDER
+  json.extract! blog_post, :id, :body
+  json.author do
+    first_name, last_name = blog_post.author_name.split(nil, 2)
+    json.first_name first_name
+    json.last_name last_name
+  end
+  json.published published
+JBUILDER
+
 COLLECTION_PARTIAL = <<-JBUILDER
   json.extract! collection, :id, :name
 JBUILDER
@@ -46,6 +56,7 @@ ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
 PARTIALS = {
   "_partial.json.jbuilder"  => "foo ||= 'hello'; json.content foo",
   "_blog_post.json.jbuilder" => BLOG_POST_PARTIAL,
+  "_blog_post_with_locals.json.jbuilder" => BLOG_POST_PARTIAL_WITH_LOCALS,
   "racers/_racer.json.jbuilder" => RACER_PARTIAL,
   "_collection.json.jbuilder" => COLLECTION_PARTIAL
 }
@@ -453,5 +464,13 @@ class JbuilderTemplateTest < ActionView::TestCase
 
     assert_not_nil result["post"]
     assert_equal 1, result["post"]["id"]
+  end
+
+  test "render array of partials with locals passed as part of the params" do
+    result = jbuild(<<-JBUILDER)
+      json.array! BLOG_POST_COLLECTION, partial: "blog_post_with_locals", as: :blog_post, published: true
+    JBUILDER
+
+    assert_equal result[0]["published"], true
   end
 end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -15,16 +15,6 @@ BLOG_POST_PARTIAL = <<-JBUILDER
   end
 JBUILDER
 
-BLOG_POST_PARTIAL_WITH_LOCALS = <<-JBUILDER
-  json.extract! blog_post, :id, :body
-  json.author do
-    first_name, last_name = blog_post.author_name.split(nil, 2)
-    json.first_name first_name
-    json.last_name last_name
-  end
-  json.published published
-JBUILDER
-
 COLLECTION_PARTIAL = <<-JBUILDER
   json.extract! collection, :id, :name
 JBUILDER
@@ -54,9 +44,8 @@ COLLECTION_COLLECTION = Array.new(5){ |i| Collection.new(i+1, "collection #{i+1}
 ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
 
 PARTIALS = {
-  "_partial.json.jbuilder"  => "foo ||= 'hello'; json.content foo",
+  "_partial.json.jbuilder"  => "json.content foo",
   "_blog_post.json.jbuilder" => BLOG_POST_PARTIAL,
-  "_blog_post_with_locals.json.jbuilder" => BLOG_POST_PARTIAL_WITH_LOCALS,
   "racers/_racer.json.jbuilder" => RACER_PARTIAL,
   "_collection.json.jbuilder" => COLLECTION_PARTIAL
 }
@@ -134,13 +123,13 @@ class JbuilderTemplateTest < ActionView::TestCase
 
   test "partial! renders partial" do
     result = jbuild(<<-JBUILDER)
-      json.partial! "partial"
+      json.partial! "partial", foo: 'hello'
     JBUILDER
 
     assert_equal "hello", result["content"]
   end
 
-  test "partial! + locals via :locals option" do
+  test "partial! + locals without :partial key with :locals key" do
     result = jbuild(<<-JBUILDER)
       json.partial! "partial", locals: { foo: "howdy" }
     JBUILDER
@@ -148,9 +137,25 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal "howdy", result["content"]
   end
 
-  test "partial! + locals without :locals key" do
+  test "partial! + locals with :partial key with :locals key" do
     result = jbuild(<<-JBUILDER)
-      json.partial! "partial", foo: "goodbye"
+      json.partial! partial: "partial", locals: { foo: "goodbye" }
+    JBUILDER
+
+    assert_equal "goodbye", result["content"]
+  end
+
+  test "partial! + locals without :partial key without :locals key" do
+    result = jbuild(<<-JBUILDER)
+      json.partial! "partial", foo: "howdy"
+    JBUILDER
+
+    assert_equal "howdy", result["content"]
+  end
+
+  test "partial! + locals with :partial key without :locals key" do
+    result = jbuild(<<-JBUILDER)
+      json.partial! partial: "partial", foo: "goodbye"
     JBUILDER
 
     assert_equal "goodbye", result["content"]
@@ -464,21 +469,5 @@ class JbuilderTemplateTest < ActionView::TestCase
 
     assert_not_nil result["post"]
     assert_equal 1, result["post"]["id"]
-  end
-
-  test "render array of partials with locals passed as part of the params" do
-    result = jbuild(<<-JBUILDER)
-      json.array! BLOG_POST_COLLECTION, partial: "blog_post_with_locals", as: :blog_post, published: true
-    JBUILDER
-
-    assert_equal result[0]["published"], true
-  end
-
-  test "render array of partials with locals passed in locals" do
-    result = jbuild(<<-JBUILDER)
-      json.array! BLOG_POST_COLLECTION, partial: "blog_post_with_locals", as: :blog_post, locals: { published: true }
-    JBUILDER
-
-    assert_equal result[0]["published"], true
   end
 end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -473,4 +473,12 @@ class JbuilderTemplateTest < ActionView::TestCase
 
     assert_equal result[0]["published"], true
   end
+
+  test "render array of partials with locals passed in locals" do
+    result = jbuild(<<-JBUILDER)
+      json.array! BLOG_POST_COLLECTION, partial: "blog_post_with_locals", as: :blog_post, locals: { published: true }
+    JBUILDER
+
+    assert_equal result[0]["published"], true
+  end
 end


### PR DESCRIPTION
This uses @SGospodinov's specs written on the report from @yusufali2205. I ran into this issue as well today and, while I don't think this necessarily the final solution, I wanted to move the conversation along.

Previous behavior: Passing objects to partial fails if the below format is used:
```
json.comments @post.comments, partial: 'comments/comment', as: :comment, show: false
```

It succeeds if locals option is used:
```
json.comments @post.comments, partial: 'comments/comment', locals: { show: false }, as: :comment
```

Swapping to options is a change to revitalize the conversation. I'm not
sure it's a permanent solution.