### PR TITLE
fix cache bug

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -295,8 +295,7 @@ class Jbuilder
 
   def _map_collection(collection)
     collection.map do |element|
-      element_result = _scope{ yield element }
-      element_result == BLANK ? BLANK : element_result.clone
+      _scope{ yield element }
     end - [BLANK]
   end
 

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -295,7 +295,8 @@ class Jbuilder
 
   def _map_collection(collection)
     collection.map do |element|
-      _scope{ yield element }
+      element_result = _scope{ yield element }
+      element_result == BLANK ? BLANK : element_result.clone
     end - [BLANK]
   end
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -135,7 +135,10 @@ class JbuilderTemplate < Jbuilder
 
   def _read_fragment_cache(key, options = nil)
     @context.controller.instrument_fragment_cache :read_fragment, key do
-      ::Rails.cache.read(key, options)
+      result = ::Rails.cache.read(key, options)
+      if !result.nil? && ::Rails.cache.is_a?(::ActiveSupport::Cache::MemoryStore)
+        result.clone
+      end
     end
   end
 

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -264,6 +264,26 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_equal "Cache", result["name"]
   end
 
+  test "fragment caching an array" do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+
+    result = jbuild(<<-JBUILDER)
+      json.array! [1, 2, 3] do |i|
+        json.cache! "cachekey" do
+          json.name "Cache#{1}"
+        end
+        json.id i
+      end
+    JBUILDER
+
+    assert_equal "Cache1", result[0]["name"]
+    assert_equal "Cache1", result[1]["name"]
+    assert_equal "Cache1", result[2]["name"]
+    assert_equal 1, result[0]["id"]
+    assert_equal 2, result[1]["id"]
+    assert_equal 3, result[2]["id"]
+  end
+
   test "conditionally fragment caching a JSON object" do
     undef_context_methods :fragment_name_with_digest, :cache_fragment_name
 


### PR DESCRIPTION
Hi,
I ran into a very strange situation.
```ruby
json.array! [1,2,3] do |i|
  json.cache! 'test' do
    json.name 'cache'
  end
  json.id i
end
```
The code above will print 
```javascript
[
  {"name":"cache","id":1},
  {"name":"cache","id":3},
  {"name":"cache","id":3}
]
```
If we move json.id on the top, it will work. The reason for that is when use cache! in the beginning of the block it will retrieve the same cached object from previous iteration and overwrite it. I think it is the same reason for this issue #330 