### PR TITLE
Single nil object should be treated as nil

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -183,7 +183,7 @@ class JbuilderTemplate < Jbuilder
 
   def _set_inline_partial(name, object, options)
     value = if object.nil?
-      []
+      nil
     elsif _is_collection?(object)
       _scope{ _render_partial_with_options options.merge(collection: object) }
     else

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -217,14 +217,6 @@ class JbuilderTemplateTest < ActionView::TestCase
     assert_collection_rendered result, "posts"
   end
 
-  test "render as empty array if partials as a nil value" do
-    result = jbuild <<-JBUILDER
-      json.posts nil, partial: "blog_post", as: :blog_post
-    JBUILDER
-
-    assert_equal [], result["posts"]
-  end
-
   test "cache an empty block" do
     undef_context_methods :fragment_name_with_digest, :cache_fragment_name
 


### PR DESCRIPTION
In response to #350

Jbuilder is currently returning an empty array when using a partial with a single object association such as:

```ruby
json.organisation @order.organisation, partial: 'v2/organisations/organisation', as: :organisation
```

This behaviour was introduced by #148 in order to return an empty array in case a collection is return nil. However this behaviour leads to the fact that all nil values are rendered as an empty array even if the association does not represent a collection or the more precise `collection` argument is used.
