### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+2.7.0
+-----
+
+* [Requires Rails 4+](https://github.com/rails/jbuilder/commit/5207ff394533177fffdd768bfaa6413a0cd16dc8)
+* [Fix implicitly rendering a JSON partial with the same name as an
+   HTML partial](https://github.com/rails/jbuilder/pull/400)
+
 2.6.4
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+2.8.0
+-----
+
+* [Replace deprecated fragment_cache_key for Rails 5.2 support](https://github.com/rails/jbuilder/pull/430)
+
 2.7.0
 -----
 

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = 'jbuilder'
-  s.version  = '2.7.0'
+  s.version  = '2.8.0'
   s.authors  = 'David Heinemeier Hansson'
   s.email    = 'david@basecamp.com'
   s.summary  = 'Create JSON structures via a Builder-style DSL'


### PR DESCRIPTION
Hello,

This pull request adds the missing changelog entries for 2.7.0 (released [a year and a half ago](https://github.com/rails/jbuilder/commit/5207ff394533177fffdd768bfaa6413a0cd16dc8)) and also release v2.8.0 as few people are waiting a new release to be able to use this gem with Rails 5.2 without having deprecation warnings.

Fixes #427.

Have a nice day !