### PR TITLE
Remove timestamps from generated partial

### DIFF
--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -10,6 +10,8 @@ module Rails
 
       argument :attributes, type: :array, default: [], banner: 'field:type field:type'
 
+      class_option :timestamps, type: :boolean, default: true
+
       def create_root_folder
         path = File.join('app/views', controller_file_path)
         empty_directory path unless File.directory?(path)
@@ -33,8 +35,12 @@ module Rails
           [name, :json, :jbuilder] * '.'
         end
 
-        def attributes_list_with_timestamps
-          attributes_list(attributes_names + %w(created_at updated_at))
+        def full_attributes_list
+          if options[:timestamps]
+            attributes_list(attributes_names + %w(created_at updated_at))
+          else
+            attributes_list(attributes_names)
+          end
         end
 
         def attributes_list(attributes = attributes_names)

--- a/lib/generators/rails/templates/partial.json.jbuilder
+++ b/lib/generators/rails/templates/partial.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! <%= singular_table_name %>, <%= attributes_list_with_timestamps %>
+json.extract! <%= singular_table_name %>, <%= full_attributes_list %>
 json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)

--- a/test/jbuilder_generator_test.rb
+++ b/test/jbuilder_generator_test.rb
@@ -27,12 +27,20 @@ class JbuilderGeneratorTest < Rails::Generators::TestCase
     assert_file 'app/views/posts/show.json.jbuilder' do |content|
       assert_match %r{json.partial! \"posts/post\", post: @post}, content
     end
-    
-    assert_file 'app/views/posts/_post.json.jbuilder' do |content|            
+
+    assert_file 'app/views/posts/_post.json.jbuilder' do |content|
       assert_match %r{json\.extract! post, :id, :title, :body}, content
+      assert_match %r{:created_at, :updated_at}, content
       assert_match %r{json\.url post_url\(post, format: :json\)}, content
     end
-    
+  end
 
+  test 'timestamps are not generated in partial with --no-timestamps' do
+    run_generator %w(Post title body:text --no-timestamps)
+
+    assert_file 'app/views/posts/_post.json.jbuilder' do |content|
+      assert_match %r{json\.extract! post, :id, :title, :body$}, content
+      assert_no_match %r{:created_at, :updated_at}, content
+    end
   end
 end


### PR DESCRIPTION
Hello,

This pull request fixes #437.

When the `--no-timestamps` option is passed to the scaffold generator, Active Record will properly remove the `created_at` and `updated_at` columns from the migration file but the generated Jbuilder partial will still reference these fields.

Have a nice day !