### PR TITLE
Tiny cleanup in the tests

### DIFF
--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -75,7 +75,7 @@ class JbuilderTest < ActiveSupport::TestCase
     end
 
     assert result.has_key?('content')
-    assert_equal nil, result['content']
+    assert_nil result['content']
   end
 
   test 'multiple keys' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,13 +4,6 @@ require 'active_support/core_ext/array/access'
 require "rails/version"
 require "jbuilder"
 
-if Rails::VERSION::STRING > "4.0"
-  require "active_support/testing/autorun"
-else
-  require "test/unit"
-end
+require "active_support/testing/autorun"
 
-
-if ActiveSupport.respond_to?(:test_order=)
-  ActiveSupport.test_order = :random
-end
+ActiveSupport.test_order = :random


### PR DESCRIPTION
Hello,

That's just a tiny pull request that cleans up a bit the test files.

Use `assert_nil` rather than `assert_equal nil, foo` since this behavior will be change to raise an error in the upcoming major version of Minitest.

Also, remove the various checks to support older versions of Rails. We are not supporting any version older than 4.2 since eb5d376. Also, `ActiveSupport.test_order` has been added in Rails 4.2 (c.f. https://github.com/rails/rails/commit/53e877f7d9291b2bf0b8c425f9e32ef35829f35b).

Have a nice day !