### PR TITLE
Fix deprecation warning for JBuilder templates

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -224,9 +224,10 @@ class JbuilderHandler
   cattr_accessor :default_format
   self.default_format = Mime[:json]
 
-  def self.call(template)
+  def self.call(template, source = nil)
+    source ||= template.source
     # this juggling is required to keep line numbers right in the error
-    %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{template.source}
+    %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{source}
       json.target! unless (__already_defined && __already_defined != "method")}
   end
 end


### PR DESCRIPTION
This commit brings the JBuilder template handler up to work with Rails 6
and no deprecation warnings.  The `JbuilderHandler.call` method should
work with older Rails versions too.

Fixes #452