### PR TITLE
Use quotes consistently in generated templates

### DIFF
--- a/lib/generators/rails/templates/index.json.jbuilder
+++ b/lib/generators/rails/templates/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @<%= plural_table_name %>, partial: '<%= plural_table_name %>/<%= singular_table_name %>', as: :<%= singular_table_name %>
+json.array! @<%= plural_table_name %>, partial: "<%= plural_table_name %>/<%= singular_table_name %>", as: :<%= singular_table_name %>


### PR DESCRIPTION
`show.json.jbuilder` uses double quotes for rendering partial, `index.json.jbuilder` uses single.