### PR TITLE
CI: Use 2.4.6, rbx-3.107

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - rbx
+  - rbx-3.107
 
 gemfile:
   - gemfiles/rails_4_2.gemfile
@@ -34,7 +34,7 @@ matrix:
       gemfile: gemfiles/rails_4_2.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails_4_2.gemfile
-    - rvm: rbx
+    - rvm: rbx-3.107
       gemfile: gemfiles/rails_4_2.gemfile
   exclude:
     - rvm: 2.5.5
@@ -49,7 +49,7 @@ matrix:
       gemfile: gemfiles/rails_head.gemfile
   allow_failures:
     - rvm: jruby-19mode
-    - rvm: rbx
+    - rvm: rbx-3.107
     - rvm: ruby-head
     - gemfile: gemfiles/rails_head.gemfile
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 
-sudo: false
 cache: bundler
 
 before_install:
@@ -10,7 +9,7 @@ before_install:
 rvm:
   - 2.2.10
   - 2.3.8
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
   - 2.6.2
   - ruby-head
@@ -46,7 +45,7 @@ matrix:
       gemfile: gemfiles/rails_head.gemfile
     - rvm: 2.3.8
       gemfile: gemfiles/rails_head.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       gemfile: gemfiles/rails_head.gemfile
   allow_failures:
     - rvm: jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
     - rvm: rbx-3.107
       gemfile: gemfiles/rails_4_2.gemfile
   exclude:
+    - rvm: 2.4.6
+      gemfile: gemfiles/rails_4_2.gemfile
     - rvm: 2.5.5
       gemfile: gemfiles/rails_4_2.gemfile
     - rvm: 2.6.2


### PR DESCRIPTION
This PR updates the CI matrix to **use 2.4.6**. To stay green, 2.4.6 is not run with Rails 4.2.

It also changes the **Rubinius** matrix member to **a version which can be installed**, but sadly, errors out on the Rake tasks.


  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration