### PR TITLE
Respect changing scaffold generator

### DIFF
--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -7,6 +7,12 @@ module Rails
       source_paths << File.expand_path('../templates', __FILE__)
 
       hook_for :jbuilder, type: :boolean, default: true
+
+      private
+
+        def permitted_params
+          attributes_names.map { |name| ":#{name}" }.join(', ')
+        end unless private_method_defined? :permitted_params
     end
   end
 end

--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -56,7 +56,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})
       <%- else -%>
-      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(<%= ":#{singular_table_name}" %>).permit(<%= permitted_params %>)
       <%- end -%>
     end
 end

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -77,7 +77,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})
       <%- else -%>
-      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(<%= ":#{singular_table_name}" %>).permit(<%= permitted_params %>)
       <%- end -%>
     end
 end

--- a/test/scaffold_api_controller_generator_test.rb
+++ b/test/scaffold_api_controller_generator_test.rb
@@ -6,7 +6,7 @@ if Rails::VERSION::MAJOR > 4
 
   class ScaffoldApiControllerGeneratorTest < Rails::Generators::TestCase
     tests Rails::Generators::ScaffoldControllerGenerator
-    arguments %w(Post title body:text --api)
+    arguments %w(Post title body:text images:attachments --api)
     destination File.expand_path('../tmp', __FILE__)
     setup :prepare_destination
 
@@ -39,7 +39,11 @@ if Rails::VERSION::MAJOR > 4
         end
 
         assert_match %r{def post_params}, content
-        assert_match %r{params\.require\(:post\)\.permit\(:title, :body\)}, content
+        if Rails::VERSION::MAJOR >= 6
+          assert_match %r{params\.require\(:post\)\.permit\(:title, :body, images: \[\]\)}, content
+        else
+          assert_match %r{params\.require\(:post\)\.permit\(:title, :body, :images\)}, content
+        end
       end
     end
 

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -4,7 +4,7 @@ require 'generators/rails/scaffold_controller_generator'
 
 class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::ScaffoldControllerGenerator
-  arguments %w(Post title body:text)
+  arguments %w(Post title body:text images:attachments)
   destination File.expand_path('../tmp', __FILE__)
   setup :prepare_destination
 
@@ -51,7 +51,11 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_match %r{def post_params}, content
-      assert_match %r{params\.require\(:post\)\.permit\(:title, :body\)}, content
+      if Rails::VERSION::MAJOR >= 6
+        assert_match %r{params\.require\(:post\)\.permit\(:title, :body, images: \[\]\)}, content
+      else
+        assert_match %r{params\.require\(:post\)\.permit\(:title, :body, :images\)}, content
+      end
     end
   end
 


### PR DESCRIPTION
The params generation was cut out to a method in https://github.com/rails/rails/pull/35805.
This is to handle the attachments field.

So use the method in jbuilder as well. Without this, a permit to handle arrays is not generated if attachments field is specified.