### PR TITLE
Add rich_text, attachment, and attachments fields support

### DIFF
--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -50,6 +50,10 @@ module Rails
 
           attributes.map { |a| ":#{a}"} * ', '
         end
+
+        def virtual_attributes
+          attributes.select {|name| name.respond_to?(:virtual?) && name.virtual? }
+        end
     end
   end
 end

--- a/lib/generators/rails/templates/partial.json.jbuilder
+++ b/lib/generators/rails/templates/partial.json.jbuilder
@@ -1,2 +1,16 @@
 json.extract! <%= singular_table_name %>, <%= full_attributes_list %>
 json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)
+<%- virtual_attributes.each do |attribute| -%>
+<%- if attribute.type == :rich_text -%>
+json.<%= attribute.name %> <%= singular_table_name %>.<%= attribute.name %>.to_s
+<%- elsif attribute.type == :attachment -%>
+json.<%= attribute.name %> url_for(<%= singular_table_name %>.<%= attribute.name %>)
+<%- elsif attribute.type == :attachments -%>
+json.<%= attribute.name %> do
+  json.array!(<%= singular_table_name %>.<%= attribute.name %>) do |<%= attribute.singular_name %>|
+    json.id <%= attribute.singular_name %>.id
+    json.url url_for(<%= attribute.singular_name %>)
+  end
+end
+<%- end -%>
+<%- end -%>

--- a/test/jbuilder_generator_test.rb
+++ b/test/jbuilder_generator_test.rb
@@ -43,4 +43,16 @@ class JbuilderGeneratorTest < Rails::Generators::TestCase
       assert_no_match %r{:created_at, :updated_at}, content
     end
   end
+
+  if Rails::VERSION::MAJOR >= 6
+    test 'handles virtual attributes' do
+      run_generator %w(Message content:rich_text video:attachment photos:attachments)
+
+      assert_file 'app/views/messages/_message.json.jbuilder' do |content|
+        assert_match %r{json\.content message\.content\.to_s}, content
+        assert_match %r{json\.video url_for\(message\.video\)}, content
+        assert_match %r{json\.photos do\n  json\.array!\(message\.photos\) do \|photo\|\n    json\.id photo\.id\n    json\.url url_for\(photo\)\n  end\nend}, content
+      end
+    end
+  end
 end

--- a/test/scaffold_api_controller_generator_test.rb
+++ b/test/scaffold_api_controller_generator_test.rb
@@ -55,5 +55,16 @@ if Rails::VERSION::MAJOR > 4
         assert_match %r{params\.fetch\(:post, \{\}\)}, content
       end
     end
+
+
+    if Rails::VERSION::MAJOR >= 6
+      test 'handles virtual attributes' do
+        run_generator ["Message", "content:rich_text", "video:attachment", "photos:attachments"]
+
+        assert_file 'app/controllers/messages_controller.rb' do |content|
+          assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+        end
+      end
+    end
   end
 end

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -67,4 +67,14 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match %r{params\.fetch\(:post, \{\}\)}, content
     end
   end
+
+  if Rails::VERSION::MAJOR >= 6
+    test 'handles virtual attributes' do
+      run_generator %w(Message content:rich_text video:attachment photos:attachments)
+
+      assert_file 'app/controllers/messages_controller.rb' do |content|
+        assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+      end
+    end
+  end
 end


### PR DESCRIPTION
I just added support for generating models with `rich_text`, `attachment` and `attachments` fields for ActionText and ActiveStorage to Rails 6 recently.

This updates jbuilder's scaffold generator to also support these fields and retains the old functionality for older Rails versions.