### PR TITLE
Update comment in controller generator templates

### DIFF
--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -51,7 +51,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
+    # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -72,7 +72,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
+    # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})


### PR DESCRIPTION
In 2013 this comment was updated in
rails/rails@3f9baeb2ec08138a0da09870ae60fd6b8165c07f to say "Only allow
a trusted parameter "white list" through." but no one ever noticed that
it didn't update in an app that used jbuilder.

jbuilder uses the same generators as Rails and actually overrides them
when you do a scaffold generator with jbuilder installed. That means
that this comment had the old text since 2013. Oops.

In #33681 we also stopped using "whitelist" in Rails so I've updated
this text and the text in Rails to remove this reference. See
rails/rails#37390