### PR TITLE
Gemfile for 5.2: use 5-2-stable branch

### DIFF
--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -2,9 +2,11 @@
 
 source "https://rubygems.org"
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 gem "rake"
 gem "mocha", require: false
 gem "appraisal"
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 5.2", github: 'rails/rails', branch: '5-2-stable'
 
 gemspec path: "../"


### PR DESCRIPTION
Fixes #479.

- Set the chosen Git source for the 5.2 gemfile to a specific branch in the rails repo

Before this change, there was a safe navigation issue which failed on 2.2.10, which does not support safe navigation.