### PR TITLE
CI: Set dist: trusty for Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - rbx-3.107
 
 gemfile:
   - gemfiles/rails_5_0.gemfile
@@ -23,6 +22,27 @@ gemfile:
   - gemfiles/rails_head.gemfile
 
 matrix:
+  include:
+    - name: "Rubinius - 5.0"
+      rvm: rbx-3.107
+      dist: trusty
+      gemfile: gemfiles/rails_5_0.gemfile
+    - name: "Rubinius - 5.1"
+      rvm: rbx-3.107
+      dist: trusty
+      gemfile: gemfiles/rails_5_1.gemfile
+    - name: "Rubinius - 5.2"
+      rvm: rbx-3.107
+      dist: trusty
+      gemfile: gemfiles/rails_5_2.gemfile
+    - name: "Rubinius - 6.0"
+      rvm: rbx-3.107
+      dist: trusty
+      gemfile: gemfiles/rails_6_0.gemfile
+    - name: "Rubinius - head"
+      rvm: rbx-3.107
+      dist: trusty
+      gemfile: gemfiles/rails_head.gemfile
   exclude:
     - rvm: 2.2.10
       gemfile: gemfiles/rails_6_0.gemfile

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -11,6 +11,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 5.0.0'
 
+  if RUBY_ENGINE == 'rbx'
+    s.add_development_dependency('racc')
+    s.add_development_dependency('json')
+    s.add_development_dependency('rubysl')
+  end
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
 end


### PR DESCRIPTION
This PR

- configures the Travis "dist" to a Rubinius-supporting one.
- adds gems that rbx needs to the gemspec

When we know more which of these matrix combination elements are even theoretically supported, we may be able to make the matrix smaller.