### PR TITLE
Test helper: Use new Mocha setup method

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require "rails/version"
 require "jbuilder"
 
 require "active_support/testing/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 
 ActiveSupport.test_order = :random
 


### PR DESCRIPTION
This PR changes how Mocha is set up in the test helper.

  - this avoids this warning: Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'