### PR TITLE
Fix kwargs usage for Ruby 2.7

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -164,7 +164,7 @@ class JbuilderTemplate < Jbuilder
     if @context.respond_to?(:cache_fragment_name)
       # Current compatibility, fragment_name_with_digest is private again and cache_fragment_name
       # should be used instead.
-      @context.cache_fragment_name(key, options)
+      @context.cache_fragment_name(key, **options)
     elsif @context.respond_to?(:fragment_name_with_digest)
       # Backwards compatibility for period of time when fragment_name_with_digest was made public.
       @context.fragment_name_with_digest(key)


### PR DESCRIPTION
This PR intend to fix a deprecation warning on Ruby 2.7. The method `cache_fragment_name` take keyword arguments. Since Ruby 2.7 a deprecation warning is diplayed when calling this method.

source: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/