### PR TITLE
Silently attempt to fetch non-existent hash value

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -254,7 +254,7 @@ class Jbuilder
   private
 
   def _extract_hash_values(object, attributes)
-    attributes.each{ |key| _set_value key, object.fetch(key) }
+    attributes.each{ |key| _set_value key, object.fetch(key, BLANK) }
   end
 
   def _extract_method_values(object, attributes)

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -450,6 +450,34 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal       2, result.second['id']
   end
 
+  test 'extract hash keys directly from array' do
+    comments = [ { content: 'hello', id: 1 }, { content: 'world', id: 2 } ]
+
+    result = jbuild do |json|
+      json.array! comments, :content, :id
+    end
+
+    assert_equal 'hello', result.first['content']
+    assert_equal       1, result.first['id']
+    assert_equal 'world', result.second['content']
+    assert_equal       2, result.second['id']
+  end
+
+  test 'missing hash keys ' do
+    comments = [ { content: 'hello', id: 1, meta: 'meta' }, { content: 'world', id: 2 } ]
+
+    result = jbuild do |json|
+      json.array! comments, :content, :id, :meta
+    end
+
+    assert_equal 'hello', result.first['content']
+    assert_equal       1, result.first['id']
+    assert_equal  'meta', result.first['meta']
+    assert_equal 'world', result.second['content']
+    assert_equal       2, result.second['id']
+    assert_nil            result.second['meta']
+  end
+
   test 'empty top-level array' do
     comments = []
 


### PR DESCRIPTION
When the `array!` method attempts to read a non-existent hash value it raises the `KeyError` error because it uses `Hash#fetch` method under the hood without the second argument.
This case is not covered with tests(the Hash case is not covered at all) so I assume it is not the expected behavior.
I cannot find any arguments when this behavior might be useful.

This PR fixes this issue and makes sure an attempt to read a non-existent hash value returns `nil`