### PR TITLE
Improve key formatting for nested hashes and disable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,25 @@ environment.rb for example):
 Jbuilder.key_format camelize: :lower
 ```
 
+By default, key format is not applied to keys of hashes that are
+passed to methods like `set!`, `array!` or `merge!`. You can opt into
+deeply transforming these as well:
+
+``` ruby
+json.key_format! camelize: :lower
+json.deep_format_keys!
+json.settings([{some_value: "abc"}])
+
+# => { "settings": [{ "someValue": "abc" }]}
+```
+
+You can set this globally with the class method `deep_format_keys` (from inside your
+environment.rb for example):
+
+``` ruby
+Jbuilder.deep_format_keys true
+```
+
 ## Contributing to Jbuilder
 
 Jbuilder is the work of many contributors. You're encouraged to submit pull requests, propose


### PR DESCRIPTION
Since #486, key format is applied deeply to hashes and arrays that are
passed to `set!`, `merge!` and `array!`:

    json.key_format! :upcase
    json.set!(:foo, {some: "value"})

    # => {"FOO": {"SOME": "value"}}

    json.key_format! :upcase
    json.merge!({some: "value"})

    # => {"SOME": "value"}

    json.key_format! :upcase
    json.array!([{some: "value"}])

    # => [{"SOME": "value"}]

This also works for arrays and hashes extracted from objects:

    comment = Struct.new(:author).new({ first_name: 'John', last_name: 'Doe' })

    json.key_format! camlize: :lower
    json.set!(:comment, comment, :author)

    # => {"comment": {"author": {"firstName": "John", "lastName": "Doe"}}}

This breaks code that relied on the previous behavior. Add a
`deep_format_keys!` directive that can be used to opt into this new
behavior and disable it by default.

     json.key_format! camelize: :lower
     json.deep_format_keys!
     json.settings({some_value: "abc"})

     # => { "settings": { "someValue": "abc" }}

Moreover, as a side effect of #486, key format was also applied to the
result of nested blocks, making it impossible to change key format in
the scope of a block:

    json.key_format! camelize: :lower
    json.level_one do
      json.key_format! :upcase
      json.value 'two'
    end

    # => jbuilder 2.10.0: {"levelOne": {"VALUE": "two"}}
    # => jbuilder 2.11.0: {"levelOne": {"vALUE": "two"}}

The string "vALUE" results from calling
`"value".upcase.camelize(:lower)`. The same happens when trying to
change the key format inside of an `array!` block.

This happens since key transformation was added in the `_merge_values`
method, which is used both by `merge!` but also when `set!` is called
with a block.

To restore the previous behavior, we pull the `_transform_keys` call
up into `merge!` itself. To make sure extracted hashes and arrays keep
being transformed (see comment/author example above), we apply
`_transform_keys` in `_extract_hash_values` and
`_extract_method_values`.

This also aligns the behavior of `extract!` which was left out in #486:

    comment = {author: { first_name: 'John', last_name: 'Doe' }}

    result = jbuild do |json|
      json.key_format! camelize: :lower
      json.extract! comment, :author
    end

    # => jbuilder 2.10 and 2.11: {"author": { :first_name => "John", :last_name => "Doe" }}
    # => now: {"author": { "firstName": "John", "lastName": "Doe" }}

Finally, to fix `array!`, we make it call `_merge_values` directly
instead of relying on `merge!`. `array!` then has to transform keys
itself when a collection is passed to preserve the new behavior
introduced by #486.