### PR TITLE
Rails use 'main' branch now.

### DIFF
--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "rake"
 gem "mocha", require: false
 gem "appraisal"
-gem "rails", github: "rails/rails"
+gem "rails", github: "rails/rails", branch: "main"
 
 gemspec path: "../"


### PR DESCRIPTION
Opening this PR, because test suite fails testing against Rails 6.1 and nobody can notice, because it is not properly executed due to Rails branch name changes.