### PR TITLE
Speed up collection rendering and add support for multifetch collection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,19 +188,19 @@ It's also possible to render collections of partials:
 json.array! @posts, partial: 'posts/post', as: :post
 
 # or
-
 json.partial! 'posts/post', collection: @posts, as: :post
 
 # or
-
 json.partial! partial: 'posts/post', collection: @posts, as: :post
 
 # or
-
 json.comments @post.comments, partial: 'comments/comment', as: :comment
 ```
 
-The `as: :some_symbol` is used with partials. It will take care of mapping the passed in object to a variable for the partial. If the value is a collection (either implicitly or explicitly by using the `collection:` option, then each value of the collection is passed to the partial as the variable `some_symbol`. If the value is a singular object, then the object is passed to the partial as the variable `some_symbol`.
+The `as: :some_symbol` is used with partials. It will take care of mapping the passed in object to a variable for the
+partial. If the value is a collection (either implicitly or explicitly by using the `collection:` option, then each
+value of the collection is passed to the partial as the variable `some_symbol`. If the value is a singular object,
+then the object is passed to the partial as the variable `some_symbol`.
 
 Be sure not to confuse the `as:` option to mean nesting of the partial. For example:
 
@@ -253,6 +253,8 @@ json.bar "bar"
 # => { "bar": "bar" }
 ```
 
+## Caching
+
 Fragment caching is supported, it uses `Rails.cache` and works like caching in
 HTML templates:
 
@@ -270,9 +272,17 @@ json.cache_if! !admin?, ['v1', @person], expires_in: 10.minutes do
 end
 ```
 
-If you are rendering fragments for a collection of objects, have a look at
-`jbuilder_cache_multi` gem. It uses fetch_multi (>= Rails 4.1) to fetch
-multiple keys at once.
+Aside from that, the `:cached` options on collection rendering is available on Rails >= 6.0. This will cache the
+rendered results effectively using the multi fetch feature.
+
+```
+json.array! @posts, partial: "posts/post", as: :post, cached: true
+
+# or:
+json.comments @post.comments, partial: "comments/comment", as: :comment, cached: true
+```
+
+## Formatting Keys
 
 Keys can be auto formatted using `key_format!`, this can be used to convert
 keynames from the standard ruby_format to camelCase:

--- a/lib/jbuilder/collection_renderer.rb
+++ b/lib/jbuilder/collection_renderer.rb
@@ -1,0 +1,108 @@
+require 'delegate'
+require 'active_support/concern'
+
+begin
+  require 'action_view/renderer/collection_renderer'
+rescue LoadError
+  require 'action_view/renderer/partial_renderer'
+end
+
+class Jbuilder
+  module CollectionRenderable # :nodoc:
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def supported?
+        superclass.private_method_defined?(:build_rendered_template) && self.superclass.private_method_defined?(:build_rendered_collection)
+      end
+    end
+
+    private
+
+    def build_rendered_template(content, template, layout = nil)
+      super(content || json.attributes!, template)
+    end
+
+    def build_rendered_collection(templates, _spacer)
+      json.merge!(templates.map(&:body))
+    end
+
+    def json
+      @options[:locals].fetch(:json)
+    end
+
+    class ScopedIterator < ::SimpleDelegator # :nodoc:
+      include Enumerable
+
+      def initialize(obj, scope)
+        super(obj)
+        @scope = scope
+      end
+
+      # Rails 6.0 support:
+      def each
+        return enum_for(:each) unless block_given?
+
+        __getobj__.each do |object|
+          @scope.call { yield(object) }
+        end
+      end
+
+      # Rails 6.1 support:
+      def each_with_info
+        return enum_for(:each_with_info) unless block_given?
+
+        __getobj__.each_with_info do |object, info|
+          @scope.call { yield(object, info) }
+        end
+      end
+    end
+
+    private_constant :ScopedIterator
+  end
+
+  if defined?(::ActionView::CollectionRenderer)
+    # Rails 6.1 support:
+    class CollectionRenderer < ::ActionView::CollectionRenderer # :nodoc:
+      include CollectionRenderable
+
+      def initialize(lookup_context, options, &scope)
+        super(lookup_context, options)
+        @scope = scope
+      end
+
+      private
+        def collection_with_template(view, template, layout, collection)
+          super(view, template, layout, ScopedIterator.new(collection, @scope))
+        end
+    end
+  else
+    # Rails 6.0 support:
+    class CollectionRenderer < ::ActionView::PartialRenderer # :nodoc:
+      include CollectionRenderable
+
+      def initialize(lookup_context, options, &scope)
+        super(lookup_context)
+        @options = options
+        @scope = scope
+      end
+
+      def render_collection_with_partial(collection, partial, context, block)
+        render(context, @options.merge(collection: collection, partial: partial), block)
+      end
+
+      private
+        def collection_without_template(view)
+          @collection = ScopedIterator.new(@collection, @scope)
+
+          super(view)
+        end
+
+        def collection_with_template(view, template)
+          @collection = ScopedIterator.new(@collection, @scope)
+
+          super(view, template)
+        end
+    end
+  end
+end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -1,4 +1,5 @@
 require 'jbuilder/jbuilder'
+require 'jbuilder/collection_renderer'
 require 'action_dispatch/http/mime_type'
 require 'active_support/cache'
 
@@ -15,6 +16,38 @@ class JbuilderTemplate < Jbuilder
     super(*args)
   end
 
+  # Generates JSON using the template specified with the `:partial` option. For example, the code below will render
+  # the file `views/comments/_comments.json.jbuilder`, and set a local variable comments with all this message's
+  # comments, which can be used inside the partial.
+  #
+  # Example:
+  #
+  #   json.partial! 'comments/comments', comments: @message.comments
+  #
+  # There are multiple ways to generate a collection of elements as JSON, as ilustrated below:
+  #
+  # Example:
+  #
+  #   json.array! @posts, partial: 'posts/post', as: :post
+  #
+  #   # or:
+  #   json.partial! 'posts/post', collection: @posts, as: :post
+  #
+  #   # or:
+  #   json.partial! partial: 'posts/post', collection: @posts, as: :post
+  #
+  #   # or:
+  #   json.comments @post.comments, partial: 'comments/comment', as: :comment
+  #
+  # Aside from that, the `:cached` options is available on Rails >= 6.0. This will cache the rendered results
+  # effectively using the multi fetch feature.
+  #
+  # Example:
+  #
+  #   json.array! @posts, partial: "posts/post", as: :post, cached: true
+  #
+  #   json.comments @post.comments, partial: "comments/comment", as: :comment, cached: true
+  #
   def partial!(*args)
     if args.one? && _is_active_model?(args.first)
       _render_active_model_partial args.first
@@ -104,11 +137,30 @@ class JbuilderTemplate < Jbuilder
   private
 
   def _render_partial_with_options(options)
-    options.reverse_merge! locals: options.except(:partial, :as, :collection)
+    options.reverse_merge! locals: options.except(:partial, :as, :collection, :cached)
     options.reverse_merge! ::JbuilderTemplate.template_lookup_options
     as = options[:as]
 
-    if as && options.key?(:collection)
+    if options.key?(:collection) && (options[:collection].nil? || options[:collection].empty?)
+      array!
+    elsif as && options.key?(:collection) && CollectionRenderer.supported?
+      collection = options.delete(:collection) || []
+      partial = options.delete(:partial)
+      options[:locals].merge!(json: self)
+
+      if options.has_key?(:layout)
+        raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
+      end
+
+      if options.has_key?(:spacer_template)
+        raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
+      end
+
+      CollectionRenderer
+        .new(@context.lookup_context, options) { |&block| _scope(&block) }
+        .render_collection_with_partial(collection, partial, @context, nil)
+    elsif as && options.key?(:collection) && !CollectionRenderer.supported?
+      # For Rails <= 5.2:
       as = as.to_sym
       collection = options.delete(:collection)
       locals = options.delete(:locals)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -283,6 +283,58 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "David", result["firstName"]
   end
 
+  if JbuilderTemplate::CollectionRenderer.supported?
+    test "returns an empty array for an empty collection" do
+      result = render('json.array! @posts, partial: "post", as: :post, cached: true', posts: [])
+
+      # Do not use #assert_empty as it is important to ensure that the type of the JSON result is an array.
+      assert_equal [], result
+    end
+
+    test "supports the cached: true option" do
+      result = render('json.array! @posts, partial: "post", as: :post, cached: true', posts: POSTS)
+
+      assert_equal 10, result.count
+      assert_equal "Post #5", result[4]["body"]
+      assert_equal "Heinemeier Hansson", result[2]["author"]["last_name"]
+      assert_equal "Pavel", result[5]["author"]["first_name"]
+
+      expected = {
+        "id" => 1,
+        "body" => "Post #1",
+        "author" => {
+          "first_name" => "David",
+          "last_name" => "Heinemeier Hansson"
+        }
+      }
+
+      assert_equal expected, Rails.cache.read("post-1")
+
+      result = render('json.array! @posts, partial: "post", as: :post, cached: true', posts: POSTS)
+
+      assert_equal 10, result.count
+      assert_equal "Post #5", result[4]["body"]
+      assert_equal "Heinemeier Hansson", result[2]["author"]["last_name"]
+      assert_equal "Pavel", result[5]["author"]["first_name"]
+    end
+
+    test "raises an error on a render call with the :layout option" do
+      error = assert_raises NotImplementedError do
+        render('json.array! @posts, partial: "post", as: :post, layout: "layout"', posts: POSTS)
+      end
+
+      assert_equal "The `:layout' option is not supported in collection rendering.", error.message
+    end
+
+    test "raises an error on a render call with the :spacer_template option" do
+      error = assert_raises NotImplementedError do
+        render('json.array! @posts, partial: "post", as: :post, spacer_template: "template"', posts: POSTS)
+      end
+
+      assert_equal "The `:spacer_template' option is not supported in collection rendering.", error.message
+    end
+  end
+
   private
     def render(*args)
       JSON.load render_without_parsing(*args)
@@ -306,6 +358,9 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
       end
 
       def view.view_cache_dependencies; []; end
+      def view.combined_fragment_cache_key(key) [ key ] end
+      def view.cache_fragment_name(key, *) key end
+      def view.fragment_name_with_digest(key) key end
 
       view
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,13 @@ class << Rails
   end
 end
 
-class Post < Struct.new(:id, :body, :author_name); end
+Jbuilder::CollectionRenderer.collection_cache = Rails.cache
+
+class Post < Struct.new(:id, :body, :author_name)
+  def cache_key
+    "post-#{id}"
+  end
+end
 
 class Racer < Struct.new(:id, :name)
   extend ActiveModel::Naming
@@ -29,5 +35,3 @@ class Racer < Struct.new(:id, :name)
 end
 
 ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
-
-ActionView::Base.remove_possible_method :cache_fragment_name


### PR DESCRIPTION
This PR mainly improves two things:

 * Speed up collection rendering by taking advantage of the existing collection renderer in ActionView
 * Add support for multifetch collection handling to make it more efficient

Basically, the idea is to create a class that extends the `ActionView::CollectionRenderer` (or `ActionView::PartialRenderer` in Rails 6.0) and use the `ScopedIterator` on each iteration of the collection, so that we will be able to render JSON for each element without having to `find_template`, which is known to be slow. Aside from that, we will be able to use other features of the `render` method as well because it's the same `render` we use in a typical Rails view.

The biggest winner here is the ability to use `cached: true` that multi-fetches fragments in one shot from the cache store. This was originally proposed by @dhh here: https://github.com/rails/jbuilder/issues/399#issuecomment-306156341, but we haven't been able to implement it because of the tricky rendering logic in Jbuilder. However since Rails 6.0, the code for collection caching has been improved and more structured. As a result, I was able to extend and re-use the renderer in Jbuilder.

Here are the performance comparison:

| Variant                                                                      | multifetch | Time per request [ms] |
| :---                                                                            | :---: |             ---: |
| Version 2.10.1 (without caching)                            |  -     |     882.299 |
| Version 2.10.1 (with the existing `json.cache!`)   |  ❌  |      103.909 |
| This PR (without `cached: true` or cold)              |  -     |     662.832 |
| This PR (with `cached: true`, warmed up)           |  ✅  |         96.911 |

As you can see, collection rendering is now faster by 200ms in the example below, with the ability fo multi-fetch if needed! 


That means if there is a record that was updated, it is going to be the only record that will get re-generated:

```
$ rails c
> City.first.touch
=> true
```

And when `curl http://localhost:3000/states` is run, the following log would be displayed:

```
Started GET "/states" for ::1 at 2021-02-22 10:04:08 -0500
Processing by StatesController#index as */*
  Rendering states/index.json.jbuilder
  State Load (0.4ms)  SELECT "states".* FROM "states"
  ↳ app/views/states/index.json.jbuilder:1
  City Load (5.2ms)  SELECT "cities".* FROM "cities" WHERE "cities"."state_id" = ?  [["state_id", 129]]
  ↳ app/views/states/index.json.jbuilder:1
  Rendered collection of cities/_city.json.jbuilder [19 / 20 cache hits] (Duration: 2.9ms | Allocations: 1816)
  Rendered collection of states/_state.json.jbuilder [50 / 51 cache hits] (Duration: 107.3ms | Allocations: 59640)
  Rendered states/index.json.jbuilder (Duration: 160.0ms | Allocations: 125006)
Completed 200 OK in 161ms (Views: 155.0ms | ActiveRecord: 5.7ms | Allocations: 125215)
```

Now the existing cache has been re-used and there is only one fragment that got re-generated! This is a huge performance boost, and I have already confirmed that this works pretty well with one of my clients.

The major downside of this is that **we will have to drop support for Rails 5.2 and earlier**. Because the collection caching logic isn't as extendable as it is in Rails 6.0 and later, it was a lot more complicated to do the same in Rails 5.2. I thought that was a stopping point and decided to send this PR.

Let me know what you all think about this. Thanks!

## Remaining Todos

 * [x] Keep the compatibility with Rails <= 5.2
 * [x] Add support for Rails 6.0
 * [x] Add a bit more test coverage around the `cached: true` usage
 * [x] Add documentation to `Jbuilder::CollectionRenderer`
 * [x] Update README

## Example code

The data is based on [the 50 U.S. states](https://github.com/jasonong/List-of-US-States/blob/master/states.csv) and [cities for each state](https://raw.githubusercontent.com/grammakov/USA-cities-and-states/master/us_cities_states_counties.csv). The import script [could be found here](https://gist.github.com/yuki24/7ddb5929d2ae284354087d040e267334). The `/states.json` endpoint returns a list of all the 50 states and the first 20 cities for each state.

```ruby
# app/models/state.rb
#
# t.string "name"
# t.string "abbreviation"
# t.datetime "created_at", precision: 6, null: false
# t.datetime "updated_at", precision: 6, null: false
class State < ApplicationRecord
  has_many :cities
end
```

```ruby
# app/models/city.rb
#
# t.integer "state_id"
# t.string "name"
# t.string "county"
# t.datetime "created_at", precision: 6, null: false
# t.datetime "updated_at", precision: 6, null: false
class City < ApplicationRecord
  belongs_to :state, touch: true
end
```

```ruby
# app/controllers/states_controller.rb
class StatesController < ApplicationController
  def index
    @states = State.all.includes(:cities)
  end
end
```

```ruby
# app/views/states/index.json.jbuilder
json.array! @states, partial: "states/state", as: :state, cached: true
```

```ruby
# app/views/states/_state.json.jbuilder
json.extract! state, :id, :name, :abbreviation, :created_at, :updated_at
json.url state_url(state, format: :json)

json.cities state.cities.first(20), partial: "cities/city", as: :city, cached: true
```

```ruby
# app/views/cities/_city.json.jbuilder
json.extract! city, :id, :name, :county, :created_at, :updated_at
```

## Raw results of <code>$ ab -n100 http://localhost:3000/states.json</code>

<details>
  <summary>Version 2.10.1</summary>

```
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:
Server Hostname:        localhost
Server Port:            3000

Document Path:          /states
Document Length:        140948 bytes

Concurrency Level:      1
Time taken for tests:   88.230 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      14141100 bytes
HTML transferred:       14094800 bytes
Requests per second:    1.13 [#/sec] (mean)
Time per request:       882.299 [ms] (mean)
Time per request:       882.299 [ms] (mean, across all concurrent requests)
Transfer rate:          156.52 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   586  882 182.6    831    1568
Waiting:      586  882 182.6    831    1568
Total:        586  882 182.6    831    1568

Percentage of the requests served within a certain time (ms)
  50%    831
  66%    899
  75%    964
  80%    982
  90%   1130
  95%   1268
  98%   1527
  99%   1568
 100%   1568 (longest request)
```
</details>

<details>
  <summary>Version 2.10.1 (with <code>the existing json.cache!</code>)</summary>

```
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:
Server Hostname:        localhost
Server Port:            3000

Document Path:          /states
Document Length:        140948 bytes

Concurrency Level:      1
Time taken for tests:   10.391 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      14141100 bytes
HTML transferred:       14094800 bytes
Requests per second:    9.62 [#/sec] (mean)
Time per request:       103.909 [ms] (mean)
Time per request:       103.909 [ms] (mean, across all concurrent requests)
Transfer rate:          1329.01 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:    92  104   9.8    100     144
Waiting:       92  103   9.8     99     144
Total:         92  104   9.8    100     144

Percentage of the requests served within a certain time (ms)
  50%    100
  66%    102
  75%    107
  80%    111
  90%    122
  95%    125
  98%    129
  99%    144
 100%    144 (longest request)
```
</details>

<details>
  <summary>With this PR (without <code>cached: true</code>)</summary>

```
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:
Server Hostname:        localhost
Server Port:            3000

Document Path:          /states
Document Length:        140948 bytes

Concurrency Level:      1
Time taken for tests:   66.283 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      14141100 bytes
HTML transferred:       14094800 bytes
Requests per second:    1.51 [#/sec] (mean)
Time per request:       662.832 [ms] (mean)
Time per request:       662.832 [ms] (mean, across all concurrent requests)
Transfer rate:          208.34 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   427  663 229.6    570    1225
Waiting:      426  662 229.6    570    1225
Total:        427  663 229.6    570    1225

Percentage of the requests served within a certain time (ms)
  50%    570
  66%    663
  75%    688
  80%    715
  90%   1134
  95%   1170
  98%   1212
  99%   1225
 100%   1225 (longest request)
```
</details>

<details>
  <summary>With this PR (with <code>cached: true</code>)</summary>

```
$ ab -n100 http://localhost:3000/states
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:
Server Hostname:        localhost
Server Port:            3000

Document Path:          /states
Document Length:        140948 bytes

Concurrency Level:      1
Time taken for tests:   9.691 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      14141100 bytes
HTML transferred:       14094800 bytes
Requests per second:    10.32 [#/sec] (mean)
Time per request:       96.911 [ms] (mean)
Time per request:       96.911 [ms] (mean, across all concurrent requests)
Transfer rate:          1424.99 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    73   97  20.3     94     202
Waiting:       73   96  20.3     94     202
Total:         74   97  20.3     94     202

Percentage of the requests served within a certain time (ms)
  50%     94
  66%    102
  75%    108
  80%    110
  90%    122
  95%    138
  98%    146
  99%    202
 100%    202 (longest request)
```
</details>