### PR TITLE
Specify rails branch for rails head build

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,6 +20,6 @@ if RUBY_VERSION >= "2.5.0"
   end
 
   appraise "rails-head" do
-    gem "rails", github: "rails/rails"
+    gem "rails", github: "rails/rails", branch: "main"
   end
 end


### PR DESCRIPTION
without this change I get the error,

```
Git error: command `git rev-parse --verify master` in directory /Users/hparker/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.
Revision master does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory '/Users/hparker/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'
```