### PR TITLE
Remove compat for `fragment_name_with_digest`

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -162,12 +162,7 @@ class JbuilderTemplate < Jbuilder
 
   def _fragment_name_with_digest(key, options)
     if @context.respond_to?(:cache_fragment_name)
-      # Current compatibility, fragment_name_with_digest is private again and cache_fragment_name
-      # should be used instead.
       @context.cache_fragment_name(key, **options)
-    elsif @context.respond_to?(:fragment_name_with_digest)
-      # Backwards compatibility for period of time when fragment_name_with_digest was made public.
-      @context.fragment_name_with_digest(key)
     else
       key
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,5 +30,4 @@ end
 
 ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
 
-ActionView::Base.remove_possible_method :fragment_name_with_digest
 ActionView::Base.remove_possible_method :cache_fragment_name


### PR DESCRIPTION
jbuilder only support Rails 5.0+ which responds to `cache_fragment_name`
