### PR TITLE
Fix scaffold controller generator with namespace

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,6 +20,6 @@ if RUBY_VERSION >= "2.5.0"
   end
 
   appraise "rails-head" do
-    gem "rails", github: "rails/rails"
+    gem "rails", github: "rails/rails", branch: "main"
   end
 end

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -30,7 +30,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       if @<%= orm_instance.save %>
-        format.html { redirect_to @<%= singular_table_name %>, notice: <%= %("#{human_name} was successfully created.") %> }
+        format.html { redirect_to <%= show_helper %>, notice: <%= %("#{human_name} was successfully created.") %> }
         format.json { render :show, status: :created, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   def update
     respond_to do |format|
       if @<%= orm_instance.update("#{singular_table_name}_params") %>
-        format.html { redirect_to @<%= singular_table_name %>, notice: <%= %("#{human_name} was successfully updated.") %> }
+        format.html { redirect_to <%= show_helper %>, notice: <%= %("#{human_name} was successfully updated.") %> }
         format.json { render :show, status: :ok, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render :edit, status: :unprocessable_entity }

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -31,14 +31,14 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match %r{@post = Post\.new\(post_params\)}, m
         assert_match %r{@post\.save}, m
-        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully created\." \}}, m
+        assert_match %r{format\.html \{ redirect_to post_url\(@post\), notice: "Post was successfully created\." \}}, m
         assert_match %r{format\.json \{ render :show, status: :created, location: @post \}}, m
         assert_match %r{format\.html \{ render :new, status: :unprocessable_entity \}}, m
         assert_match %r{format\.json \{ render json: @post\.errors, status: :unprocessable_entity \}}, m
       end
 
       assert_instance_method :update, content do |m|
-        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully updated\." \}}, m
+        assert_match %r{format\.html \{ redirect_to post_url\(@post\), notice: "Post was successfully updated\." \}}, m
         assert_match %r{format\.json \{ render :show, status: :ok, location: @post \}}, m
         assert_match %r{format\.html \{ render :edit, status: :unprocessable_entity \}}, m
         assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_entity \}}, m

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -59,6 +59,25 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  if Rails::VERSION::MAJOR >= 6
+    test 'controller with namespace' do
+      run_generator %w(Admin::Post --model-name=Post)
+      assert_file 'app/controllers/admin/posts_controller.rb' do |content|
+        assert_instance_method :create, content do |m|
+          assert_match %r{format\.html \{ redirect_to admin_post_url\(@post\), notice: "Post was successfully created\." \}}, m
+        end
+
+        assert_instance_method :update, content do |m|
+          assert_match %r{format\.html \{ redirect_to admin_post_url\(@post\), notice: "Post was successfully updated\." \}}, m
+        end
+
+        assert_instance_method :destroy, content do |m|
+          assert_match %r{format\.html \{ redirect_to admin_posts_url, notice: "Post was successfully destroyed\." \}}, m
+        end
+      end
+    end
+  end
+
   test 'dont use require and permit if there are no attributes' do
     run_generator %w(Post)
 


### PR DESCRIPTION
For example:

```
bundle exec rails g scaffold_controller Admin::Post title:string content:text --model-name=Post
```

It fixes the code generated by jbuilder. There is another fix on [railties gem](https://github.com/rails/rails/pull/43611).


You can QA it modifying the Gemfile with:
```
gem "rails", github: "ceritium/rails", branch: "fix-scaffold-generator"
gem 'jbuilder', github: "ceritium/jbuilder", branch: "fix-scaffold-controller-namespace"
```

And run the following generators for example:
```ruby
bundle exec rails g model title:string content:text
bundle exec rails g scaffold_controller Admin::Post title:string content:text --model-name=Post
rake test # or just run the generated tests
```

Then you can see the code and test the generated scaffold.