### PR TITLE
Fix the test that depends on the time helper

### DIFF
--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -159,7 +159,7 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "object fragment caching with expiry" do
-    travel_to "2018-05-12 11:29:00 -0400"
+    travel_to Time.iso8601("2018-05-12T11:29:00-04:00")
 
     render <<-JBUILDER
       json.cache! "cache-key", expires_in: 1.minute do


### PR DESCRIPTION
This PR fixes the failing test in the `master` branch. The test is failing on [this line on Rails](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/testing/time_helpers.rb#L160). Apparently, the time helper is now timezone-aware after this change https://github.com/rails/rails/commit/b96f4ae1d5defd84e690d265467738901291347d, but now we have to set the default time zone to make the time helper work with string arguments.

Rather than setting a default time zone in the jbuilder test, we can just pass a Time object to get the test working.