### PR TITLE
CI: YAML formatting + Job name

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Ruby test
+    name: Ruby ${{ matrix.ruby }} (${{ matrix.gemfile }})
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.experimental }}
     env:
@@ -14,82 +14,82 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [
-          2.2.10,
-          2.3.8,
-          2.4.10,
-          2.5.8,
-          2.6.6,
-          2.7.1,
-          3.0.0
-        ]
-        gemfile: [
-          "rails_5_0",
-          "rails_5_1",
-          "rails_5_2",
-          "rails_6_0",
-          "rails_6_1",
-          "rails_head"
-        ]
+        ruby: 
+          - "2.2"
+          - "2.3"
+          - "2.4"
+          - "2.5"
+          - "2.6"
+          - "2.7"
+          - "3.0"
+
+        gemfile:
+          - "rails_5_0"
+          - "rails_5_1"
+          - "rails_5_2"
+          - "rails_6_0"
+          - "rails_6_1"
+          - "rails_head"
+        
         experimental: [false]
         exclude:
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: rails_5_0
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_5_0
           - ruby: head
             gemfile: rails_5_0
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: rails_5_1
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_5_1
           - ruby: head
             gemfile: rails_5_1
-          - ruby: 2.2.10
+          - ruby: 2.2
             gemfile: rails_5_2
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: rails_5_2
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_5_2
           - ruby: head
             gemfile: rails_5_2
-          - ruby: 2.2.10
+          - ruby: 2.2
             gemfile: rails_6_0
-          - ruby: 2.3.8
+          - ruby: 2.3
             gemfile: rails_6_0
-          - ruby: 2.4.10
+          - ruby: 2.4
             gemfile: rails_6_0
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_6_0
           - ruby: head
             gemfile: rails_6_0
-          - ruby: 2.2.10
+          - ruby: 2.2
             gemfile: rails_6_1
-          - ruby: 2.3.8
+          - ruby: 2.3
             gemfile: rails_6_1
-          - ruby: 2.4.10
+          - ruby: 2.4
             gemfile: rails_6_1
-          - ruby: 2.2.10
+          - ruby: 2.2
             gemfile: rails_head
-          - ruby: 2.3.8
+          - ruby: 2.3
             gemfile: rails_head
-          - ruby: 2.4.10
+          - ruby: 2.4
             gemfile: rails_head
-          - ruby: 2.5.8
+          - ruby: 2.5
             gemfile: rails_head
-          - ruby: 2.6.6
+          - ruby: 2.6
             gemfile: rails_head
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: rails_head
             experimental: false
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_head
             experimental: false
         include:
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: rails_head
             experimental: true
-          - ruby: 3.0.0
+          - ruby: '3.0'
             gemfile: rails_head
             experimental: true
           - ruby: head


### PR DESCRIPTION
The used YAML array-style does not pass GitHub Actions' linting. That form needs to be placed on a single line to have 0 lint warnings.

Also: add a name for the Job, which makes the output a little less cryptic.