### PR TITLE
Implement primitive! method

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,20 @@ json.partial! 'sub_template', locals: { user: user }
 json.partial! 'sub_template', user: user
 ```
 
+You can explicitly make Jbuilder object return a primitive value:
 
-You can explicitly make Jbuilder object return null if you want:
+``` ruby
+json.extract! @post, :id, :title, :content, :published_at
+json.author do
+  if @post.pseudonymous?
+    json.primitive! @post.author_pseudonym
+  else
+    json.first_name @post.author_first_name
+    json.last_name @post.author_last_name
+  end
+```
+
+Returning null is also possible:
 
 ``` ruby
 json.extract! @post, :id, :title, :content, :published_at

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -257,6 +257,17 @@ class Jbuilder
     end
   end
 
+  # Returns a primitive JSON
+  # Example:
+  #
+  #   json.primitive! "hello"
+  #
+  #   "hello"
+  def primitive!(value)
+    raise PrimitiveError.build(value) unless _is_primitive?(value)
+    @attributes = value
+  end   
+
   # Returns the nil JSON.
   def nil!
     @attributes = nil
@@ -353,6 +364,10 @@ class Jbuilder
   def _is_collection?(object)
     _object_respond_to?(object, :map, :count) && NON_ENUMERABLES.none?{ |klass| klass === object }
   end
+
+  def _is_primitive?(value)
+    (value.is_a? ::String) || (value.is_a? ::Numeric) || value == true || value == false || value.nil?
+  end  
 
   def _blank?(value=@attributes)
     BLANK == value

--- a/lib/jbuilder/errors.rb
+++ b/lib/jbuilder/errors.rb
@@ -1,6 +1,13 @@
 require 'jbuilder/jbuilder'
 
 class Jbuilder
+  class PrimitiveError < ::StandardError
+    def self.build(value)
+      message = "Can't use #{value.inspect} as primitive"
+      new(message)
+    end
+  end
+
   class NullError < ::NoMethodError
     def self.build(key)
       message = "Failed to add #{key.to_s.inspect} property to null object"

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -831,6 +831,57 @@ class JbuilderTest < ActiveSupport::TestCase
     Jbuilder.send(:class_variable_set, '@@ignore_nil', false)
   end
 
+  test 'primitive! with String value' do
+    result = jbuild do |json|
+      json.primitive! 'hello'
+    end
+
+    assert_equal 'hello', result
+  end
+
+  test 'primitive! with Numeric value' do
+    result = jbuild do |json|
+      json.primitive! 13.37
+    end
+
+    assert_equal 13.37, result
+  end
+
+  test 'primitive! with true value' do
+    result = jbuild do |json|
+      json.primitive! true
+    end
+
+    assert_equal true, result
+  end
+  
+  test 'primitive! with false value' do
+    result = jbuild do |json|
+      json.primitive! false
+    end
+
+    assert_equal false, result
+  end
+  
+  test 'primitive! with nil value' do
+    result = jbuild do |json|
+      json.primitive! nil
+    end
+
+    assert_equal nil, result
+  end
+
+  test 'primitive! in an empty block' do
+    result = jbuild do |json|
+      json.author do
+        json.primitive! 'David Heinemeier Hansson'
+      end
+    end
+
+    assert result.key?('author')
+    assert_equal 'David Heinemeier Hansson', result['author']
+  end  
+
   test 'nil!' do
     result = jbuild do |json|
       json.key 'value'
@@ -869,6 +920,14 @@ class JbuilderTest < ActiveSupport::TestCase
     assert attributes.empty?
     assert attributes.blank?
     assert !attributes.present?
+  end
+
+  test 'throws PrimitiveError when trying to use hash as primitive' do
+    assert_raise Jbuilder::PrimitiveError do
+      jbuild do |json|
+        json.primitive!({})
+      end
+    end
   end
 
   test 'throws ArrayError when trying to add a key to an array' do
@@ -929,6 +988,20 @@ class JbuilderTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "throws MergeError when trying to replace non-empty block with primitive" do
+    assert_raise Jbuilder::MergeError do
+      jbuild do |json|
+        json.author do
+          json.name 'David'
+        end
+
+        json.author do
+          json.primitive! 'David Heinemeier Hansson'
+        end
+      end
+    end
+  end 
 
   if RUBY_VERSION >= "2.2.10"
     test "respects JSON encoding customizations" do


### PR DESCRIPTION
Jbuilder returns objects, arrays and null.
But according to RFC 8259, Section 3, also numbers, strings and the literals
false and true are valid JSON. The method primitive! enables this.