### PR TITLE
Avoid loading `ActionController::API` constant

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -16,11 +16,9 @@ class Jbuilder
           end
         end
 
-        ActiveSupport.on_load :action_controller do
-          if self == ActionController::API
-            include ActionController::Helpers
-            include ActionController::ImplicitRender
-          end
+        ActiveSupport.on_load :action_controller_api do
+          include ActionController::Helpers
+          include ActionController::ImplicitRender
         end
       end
     end


### PR DESCRIPTION
Partially related to - https://github.com/rails/rails/issues/44330
Currently `self == ActionController::API` check causes `ActionController::API` to be loaded for apps that do not need it.

To avoid loading the constant I'm changing the hook to be registered on the `action_controller_api` so we always know that `self` is `API` constant if the hook is being called
 `action_controller_api` name is available from Rails `5.2.0.beta1`  - https://github.com/rails/rails/commit/35fac87123df4fdf7cc26b7ccd724932d946be87

It's fair to mention that the change isn't going to work on Rails 5 versions lower than `5.2.0`, is this something we should be concerned about? 