### PR TITLE
 Fix namespace issue when generating jbuilder views

### DIFF
--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -54,6 +54,10 @@ module Rails
         def virtual_attributes
           attributes.select {|name| name.respond_to?(:virtual?) && name.virtual? }
         end
+
+        def partial_path_name
+          [controller_file_path, singular_table_name].join("/")
+        end
     end
   end
 end

--- a/lib/generators/rails/templates/index.json.jbuilder
+++ b/lib/generators/rails/templates/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @<%= plural_table_name %>, partial: "<%= plural_table_name %>/<%= singular_table_name %>", as: :<%= singular_table_name %>
+json.array! @<%= plural_table_name %>, partial: "<%= partial_path_name %>", as: :<%= singular_table_name %>

--- a/lib/generators/rails/templates/show.json.jbuilder
+++ b/lib/generators/rails/templates/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "<%= plural_table_name %>/<%= singular_table_name %>", <%= singular_table_name %>: @<%= singular_table_name %>
+json.partial! "<%= partial_path_name %>", <%= singular_table_name %>: @<%= singular_table_name %>

--- a/test/jbuilder_generator_test.rb
+++ b/test/jbuilder_generator_test.rb
@@ -44,6 +44,18 @@ class JbuilderGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test 'namespaced views are generated correctly for index' do
+    run_generator %w(Admin::Post --model-name=Post)
+
+    assert_file 'app/views/admin/posts/index.json.jbuilder' do |content|
+      assert_match %r{json\.array! @posts, partial: "admin/posts/post", as: :post}, content
+    end
+
+    assert_file 'app/views/admin/posts/show.json.jbuilder' do |content|
+      assert_match %r{json\.partial! "admin/posts/post", post: @post}, content
+    end
+  end
+
   if Rails::VERSION::MAJOR >= 6
     test 'handles virtual attributes' do
       run_generator %w(Message content:rich_text video:attachment photos:attachments)


### PR DESCRIPTION
I was using jbuilder and found an issue with namespaces which is the same issue reported in https://github.com/rails/jbuilder/issues/474

To repro:

`bin/rails g scaffold admin/post title`

This outputs `json.array! @admin_posts, partial: "admin_posts/admin_post", as: :admin_post` which causes an error when clicking on the url http://localhost:3000/admin/posts/1.json

After this fix it's now `json.array! @admin_posts, partial: "admin/posts/admin_post", as: :admin_post`.

This fix was already suggested over https://github.com/rails/jbuilder/pull/492 I have added tests and added the original author as co-author.