### PR TITLE
Document Testing configuration for RSpec users

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Jbuilder.deep_format_keys true
 
 ## Testing JBuilder Response body with RSpec
 
-For `rspec-rails` users, to test the response body of your controller spec, enable `render_views` in your RSpec context. This [configuration](https://relishapp.com/rspec/rspec-rails/v/5-1/docs/controller-specs/render-views) renders the views in a controller test.
+To test the response body of your controller spec, enable `render_views` in your RSpec context. This [configuration](https://relishapp.com/rspec/rspec-rails/v/5-1/docs/controller-specs/render-views) renders the views in a controller test.
 
 ## Contributing to Jbuilder
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Jbuilder.deep_format_keys true
 
 ## Testing JBuilder Response body with RSpec
 
-To test the response body of your controller spec, enable `render_views` in your RSpec context. This [configuration](https://relishapp.com/rspec/rspec-rails/v/5-1/docs/controller-specs/render-views) renders the views in a controller test.
+To test the response body of your controller spec, enable `render_views` in your RSpec context. This [configuration](https://rspec.info/features/6-0/rspec-rails/controller-specs/render-views) renders the views in a controller test.
 
 ## Contributing to Jbuilder
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ environment.rb for example):
 Jbuilder.deep_format_keys true
 ```
 
+## Testing JBuilder Response body with RSpec
+
+For `rspec-rails` users, to test the response body of your controller spec, enable `render_views` in your RSpec context. This [configuration](https://relishapp.com/rspec/rspec-rails/v/5-1/docs/controller-specs/render-views) renders the views in a controller test.
+
 ## Contributing to Jbuilder
 
 Jbuilder is the work of many contributors. You're encouraged to submit pull requests, propose


### PR DESCRIPTION
JBuilder documentation does not guide users to any extra configuration to test the response body of a template.

Searching for "Rspec" in the project, we see that there are lots of closed issues related to this issue.

Although this extra configuration is not related to JBuilder, I believe this is an important thing to have in the documentation. Users clearly need that extra guidance.

Including a note about it in the documentation would save users hours of trying to debug JBuilder, and maintainers hours that could be used on another features.

Opening this PR for a discussion. I am not sure this is the best place to put this note. Any suggestions?