### PR TITLE
Fix warnings on Ruby 2.7

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -26,12 +26,12 @@ class Jbuilder
   BLANK = Blank.new
   NON_ENUMERABLES = [ ::Struct, ::OpenStruct ].to_set
 
-  def set!(key, value = BLANK, *args)
+  def set!(key, value = BLANK, *args, &block)
     result = if ::Kernel.block_given?
       if !_blank?(value)
         # json.comments @post.comments { |comment| ... }
         # { "comments": [ { ... }, { ... } ] }
-        _scope{ array! value, &::Proc.new }
+        _scope{ array! value, &block }
       else
         # json.comments { ... }
         # { "comments": ... }
@@ -61,9 +61,9 @@ class Jbuilder
     _set_value key, result
   end
 
-  def method_missing(*args)
+  def method_missing(*args, &block)
     if ::Kernel.block_given?
-      set!(*args, &::Proc.new)
+      set!(*args, &block)
     else
       set!(*args)
     end
@@ -181,11 +181,11 @@ class Jbuilder
   #   json.array! [1, 2, 3]
   #
   #   [1,2,3]
-  def array!(collection = [], *attributes)
+  def array!(collection = [], *attributes, &block)
     array = if collection.nil?
       []
     elsif ::Kernel.block_given?
-      _map_collection(collection, &::Proc.new)
+      _map_collection(collection, &block)
     elsif attributes.any?
       _map_collection(collection) { |element| extract! element, *attributes }
     else
@@ -220,9 +220,9 @@ class Jbuilder
     end
   end
 
-  def call(object, *attributes)
+  def call(object, *attributes, &block)
     if ::Kernel.block_given?
-      array! object, &::Proc.new
+      array! object, &block
     else
       extract! object, *attributes
     end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -73,8 +73,8 @@ class JbuilderTemplate < Jbuilder
   #   json.cache_if! !admin?, @person, expires_in: 10.minutes do
   #     json.extract! @person, :name, :age
   #   end
-  def cache_if!(condition, *args)
-    condition ? cache!(*args, &::Proc.new) : yield
+  def cache_if!(condition, *args, &block)
+    condition ? cache!(*args, &block) : yield
   end
 
   def target!


### PR DESCRIPTION
This PR attempts to fix the ruby 2.7 warnings regarding empty Proc.new . This also enables to upgrade to ruby3.

Clone PR - https://github.com/rails/jbuilder/pull/468/files