### PR TITLE
Adds Ruby 3.2 to CI. Updates checkout action version.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
 
         gemfile:
           - "rails_5_0"
@@ -41,6 +42,8 @@ jobs:
             gemfile: rails_5_0
           - ruby: '3.1'
             gemfile: rails_5_0
+          - ruby: '3.2'
+            gemfile: rails_5_0
           - ruby: head
             gemfile: rails_5_0
           - ruby: 2.7
@@ -49,6 +52,8 @@ jobs:
             gemfile: rails_5_1
           - ruby: '3.1'
             gemfile: rails_5_1
+          - ruby: '3.2'
+            gemfile: rails_5_1
           - ruby: head
             gemfile: rails_5_1
           - ruby: 2.2
@@ -59,6 +64,8 @@ jobs:
             gemfile: rails_5_2
           - ruby: '3.1'
             gemfile: rails_5_2
+          - ruby: '3.2'
+            gemfile: rails_5_2
           - ruby: head
             gemfile: rails_5_2
           - ruby: 2.2
@@ -71,6 +78,8 @@ jobs:
             gemfile: rails_6_0
           - ruby: '3.1'
             gemfile: rails_6_0
+          - ruby: '3.2'
+            gemfile: rails_6_0
           - ruby: head
             gemfile: rails_6_0
           - ruby: 2.2
@@ -108,15 +117,15 @@ jobs:
           - ruby: '3.1'
             gemfile: rails_head
             experimental: false
+          - ruby: '3.2'
+            gemfile: rails_head
+            experimental: false
 
         include:
-          - ruby: 2.7
-            gemfile: rails_head
-            experimental: true
-          - ruby: '3.0'
-            gemfile: rails_head
-            experimental: true
           - ruby: '3.1'
+            gemfile: rails_head
+            experimental: true
+          - ruby: '3.2'
             gemfile: rails_head
             experimental: true
           - ruby: head
@@ -124,7 +133,7 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Also removed Ruby 2.7 and 3.0 for rails_head.

Runs green on my fork.