### PR TITLE
Add a test for `render collection:, cached: true`

### DIFF
--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -73,6 +73,14 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "Pavel", result[5]["author"]["first_name"]
   end
 
+  test "partial collection by name with caching" do
+    result = render('json.partial! "post", collection: @posts, cached: true, as: :post', posts: POSTS)
+    assert_equal 10, result.count
+    assert_equal "Post #5", result[4]["body"]
+    assert_equal "Heinemeier Hansson", result[2]["author"]["last_name"]
+    assert_equal "Pavel", result[5]["author"]["first_name"]
+  end
+
   test "partial collection by name with string local" do
     result = render('json.partial! "post", collection: @posts, as: "post"', posts: POSTS)
     assert_equal 10, result.count


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/48936

`jbuilder` template bodies not being String tend to make Action View much more tricky than it need to be.

I'm very unfamiliar with `jbuilder`, but it seems to me that in theory it could cache actual `json` fragments rather than complex ruby objects.

That would be both faster and stop breaking assumptions in Action View.