### PR TITLE
Fix require path of dependency_tracker in railtie.rb

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -6,7 +6,7 @@ class Jbuilder
     initializer :jbuilder do
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
-        require 'jbuilder/dependency_tracker'
+        require 'jbuilder/jbuilder_dependency_tracker'
       end
 
       if Rails::VERSION::MAJOR >= 5


### PR DESCRIPTION
```
LoadError: cannot load such file -- jbuilder/dependency_tracker
```

Introduced in https://github.com/rails/jbuilder/commit/710979958aa012f4ff21800abf5bd50b717df0a6