### PR TITLE
Add Jets Support

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -364,3 +364,4 @@ class Jbuilder
 end
 
 require 'jbuilder/railtie' if defined?(Rails)
+require 'jbuilder/turbine' if defined?(::Jets::Turbine)

--- a/lib/jbuilder/turbine.rb
+++ b/lib/jbuilder/turbine.rb
@@ -1,0 +1,13 @@
+require 'jets'
+require 'jbuilder/jbuilder_template'
+
+class Jbuilder
+  class Engine < ::Jets::Engine
+    initializer :jbuilder do
+      ActiveSupport.on_load :action_view do
+        ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
+        require 'jbuilder/jbuilder_dependency_tracker'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds [Jets](https://rubyonjets.com/) support to jbuilder.

* Adds a Jets Turbine, which is like a Railtie, that registers the plugin with the Jets Framework.
* This would spare the need for this forked gem [jbuilder-jets](https://github.com/rubyonjets/jbuilder-jets)

Thanks for considering this PR. No sweat either way of course. 👍