### PR TITLE
Run Railtie from the tests so that we can detect bugs inside Railtie

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -16,9 +16,11 @@ class Jbuilder
           end
         end
 
-        ActiveSupport.on_load :action_controller_api do
-          include ActionController::Helpers
-          include ActionController::ImplicitRender
+        ActiveSupport.on_load :action_controller do
+          if name == 'ActionController::API'
+            include ActionController::Helpers
+            include ActionController::ImplicitRender
+          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require "active_support/core_ext/array/access"
 require "active_support/cache/memory_store"
 require "active_support/json"
 require "active_model"
+require 'action_controller/railtie'
+require 'action_view/railtie'
 
 require "active_support/testing/autorun"
 require "mocha/minitest"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,4 +35,3 @@ class Racer < Struct.new(:id, :name)
   include ActiveModel::Conversion
 end
 
-ActionView::Template.register_template_handler :jbuilder, JbuilderHandler

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,3 +35,11 @@ class Racer < Struct.new(:id, :name)
   include ActiveModel::Conversion
 end
 
+# Instantiate an Application in order to trigger the initializers
+Class.new(Rails::Application) do
+  config.secret_key_base = 'secret'
+  config.eager_load = false
+end.initialize!
+
+# Touch AV::Base in order to trigger :action_view on_load hook before running the tests
+ActionView::Base.inspect


### PR DESCRIPTION
#552 seems like a valid fix. The `require` statement seems to be requiring something that no longer exists. Then why isn't the CI failing? It should be because the Jbuilder Railtie is not executed during the tests.

So, here's an attempt to make the CI run the Railtie. Let's see if the CI properly fails now...