### PR TITLE
Support Strict Locals

### DIFF
--- a/lib/generators/rails/templates/partial.json.jbuilder
+++ b/lib/generators/rails/templates/partial.json.jbuilder
@@ -1,3 +1,5 @@
+# locals: (<%= singular_table_name %>:)
+
 json.extract! <%= singular_table_name %>, <%= full_attributes_list %>
 json.url <%= singular_table_name %>_url(<%= singular_table_name %>, format: :json)
 <%- virtual_attributes.each do |attribute| -%>

--- a/test/jbuilder_generator_test.rb
+++ b/test/jbuilder_generator_test.rb
@@ -29,6 +29,7 @@ class JbuilderGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file 'app/views/posts/_post.json.jbuilder' do |content|
+      assert_match %r{# locals: \(post:\)}, content
       assert_match %r{json\.extract! post, :id, :title, :body}, content
       assert_match %r{:created_at, :updated_at}, content
       assert_match %r{json\.url post_url\(post, format: :json\)}, content

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -3,6 +3,7 @@ require "action_view/testing/resolvers"
 
 class JbuilderTemplateTest < ActiveSupport::TestCase
   POST_PARTIAL = <<-JBUILDER
+    # locals: (json:, post:)
     json.extract! post, :id, :body
     json.author do
       first_name, last_name = post.author_name.split(nil, 2)


### PR DESCRIPTION
When scaffolding out partials, generate template files with a [Strict Locals][] magic comment based on the name of the resource (for example, `# locals: (post:)` when generating `_post.json.jbuilder`).

[Strict Locals]: https://guides.rubyonrails.org/action_view_overview.html#strict-locals