### PR TITLE
Use OpenStruct only if available

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -4,8 +4,11 @@ require 'jbuilder/blank'
 require 'jbuilder/key_formatter'
 require 'jbuilder/errors'
 require 'json'
-require 'ostruct'
 require 'active_support/core_ext/hash/deep_merge'
+begin
+  require 'ostruct'
+rescue LoadError
+end
 
 class Jbuilder
   @@key_formatter = nil
@@ -28,7 +31,7 @@ class Jbuilder
   end
 
   BLANK = Blank.new
-  NON_ENUMERABLES = [ ::Struct, ::OpenStruct ].to_set
+  NON_ENUMERABLES = defined?(::OpenStruct) ? [::Struct, ::OpenStruct].to_set : [::Struct].to_set
 
   def set!(key, value = BLANK, *args, &block)
     result = if ::Kernel.block_given?


### PR DESCRIPTION
This commit uses OpenStruct only if available because of the following reasons:

- Starting from Ruby 3.4.0dev, Using `ostruct` raises the following warning.
> ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.

- And when the warning category is `:performance` it also raises this warning.
> "OpenStruct use is discouraged for performance reasons

Refer to
https://bugs.ruby-lang.org/issues/20309
https://github.com/ruby/ruby/pull/10428
https://github.com/ruby/ostruct/pull/56
Fix #561