### PR TITLE
Replace deprecated `ProxyObject` with `BasicObject`

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -292,7 +292,7 @@ class Jbuilder
 
   def _merge_block(key)
     current_value = _blank? ? BLANK : @attributes.fetch(_key(key), BLANK)
-    raise NullError.build(key) if current_value.nil?
+    ::Kernel.raise NullError.build(key) if current_value.nil?
     new_value = _scope{ yield self }
     _merge_values(current_value, new_value)
   end
@@ -307,7 +307,7 @@ class Jbuilder
     elsif ::Hash === current_value && ::Hash === updates
       current_value.deep_merge(updates)
     else
-      raise MergeError.build(current_value, updates)
+      ::Kernel.raise MergeError.build(current_value, updates)
     end
   end
 
@@ -328,8 +328,8 @@ class Jbuilder
   end
 
   def _set_value(key, value)
-    raise NullError.build(key) if @attributes.nil?
-    raise ArrayError.build(key) if ::Array === @attributes
+    ::Kernel.raise NullError.build(key) if @attributes.nil?
+    ::Kernel.raise ArrayError.build(key) if ::Array === @attributes
     return if @ignore_nil && value.nil? or _blank?(value)
     @attributes = {} if _blank?
     @attributes[_key(key)] = value

--- a/lib/jbuilder/jbuilder.rb
+++ b/lib/jbuilder/jbuilder.rb
@@ -1,7 +1,1 @@
-Jbuilder = Class.new(begin
-  require 'active_support/proxy_object'
-  ActiveSupport::ProxyObject
-rescue LoadError
-  require 'active_support/basic_object'
-  ActiveSupport::BasicObject
-end)
+Jbuilder = Class.new(BasicObject)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -89,7 +89,7 @@ class JbuilderTemplate < Jbuilder
   #   # json.extra 'This will not work either, the root must be exclusive'
   def cache_root!(key=nil, options={})
     if @context.controller.perform_caching
-      raise "cache_root! can't be used after JSON structures have been defined" if @attributes.present?
+      ::Kernel.raise "cache_root! can't be used after JSON structures have been defined" if @attributes.present?
 
       @cached_root = _cache_fragment_for([ :root, key ], options) { yield; target! }
     else
@@ -148,11 +148,11 @@ class JbuilderTemplate < Jbuilder
       collection = EnumerableCompat.new(collection) if collection.respond_to?(:count) && !collection.respond_to?(:size)
 
       if options.has_key?(:layout)
-        raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
+        ::Kernel.raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
       end
 
       if options.has_key?(:spacer_template)
-        raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
+        ::Kernel.raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
       end
 
       results = CollectionRenderer


### PR DESCRIPTION
It has been deprecated in https://github.com/rails/rails/pull/51638

Note that `ProxyObject` defines the `raise` method. So it must now be called explicitly from Kernel since `BasicObject` doesn't do that.