### PR TITLE
Add base64 to gemfiles

### DIFF
--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 6.0.0"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 6.1.0"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 7.0.0"
+gem "base64"
 
 gemspec path: "../"


### PR DESCRIPTION
This commit adds base64 gem to rails_6_0.gemfiles, rails_6_1.gemfiles and rails_7_0.gemfiles in gemfiles directory for the following reasons.

- Starting from Ruby 3.3, using base64 raises the following warning.

> warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of activesupport-6.0.6.1 to add base64 into its gemspec.

- The reason for not adding gems to rails7_1.gemfiles and rails_head.gemfiles is that the base64 gem has been added to activesupport.gemspec since ActiveSupport 7.1 with add_dependency.

However, we do not add base64 gem to jbuilder.gemspec for the following reason.

- jbuilder supports Ruby 2.2, but initial version (v0.1.0) of base64 gem supports Ruby 2.3 and above. Therefore if we add base64 to jbuilder.gemspec, it fails while running the `bundle install` command.

Refer to
https://bugs.ruby-lang.org/issues/20187
https://github.com/ruby/ruby/pull/9550
https://github.com/rails/rails/blob/v7.1.0/activesupport/activesupport.gemspec
https://github.com/ruby/base64/blob/v0.1.0/base64.gemspec