### PR TITLE
Redirect to `@record` or path in controller generator

### DIFF
--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -30,7 +30,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
     respond_to do |format|
       if @<%= orm_instance.save %>
-        format.html { redirect_to <%= show_helper %>, notice: <%= %("#{human_name} was successfully created.") %> }
+        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %> }
         format.json { render :show, status: :created, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   def update
     respond_to do |format|
       if @<%= orm_instance.update("#{singular_table_name}_params") %>
-        format.html { redirect_to <%= show_helper %>, notice: <%= %("#{human_name} was successfully updated.") %> }
+        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %> }
         format.json { render :show, status: :ok, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -57,7 +57,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= orm_instance.destroy %>
 
     respond_to do |format|
-      format.html { redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %> }
+      format.html { redirect_to <%= index_helper %>_path, notice: <%= %("#{human_name} was successfully destroyed.") %> }
       format.json { head :no_content }
     end
   end

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -31,14 +31,14 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match %r{@post = Post\.new\(post_params\)}, m
         assert_match %r{@post\.save}, m
-        assert_match %r{format\.html \{ redirect_to post_url\(@post\), notice: "Post was successfully created\." \}}, m
+        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully created\." \}}, m
         assert_match %r{format\.json \{ render :show, status: :created, location: @post \}}, m
         assert_match %r{format\.html \{ render :new, status: :unprocessable_entity \}}, m
         assert_match %r{format\.json \{ render json: @post\.errors, status: :unprocessable_entity \}}, m
       end
 
       assert_instance_method :update, content do |m|
-        assert_match %r{format\.html \{ redirect_to post_url\(@post\), notice: "Post was successfully updated\." \}}, m
+        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully updated\." \}}, m
         assert_match %r{format\.json \{ render :show, status: :ok, location: @post \}}, m
         assert_match %r{format\.html \{ render :edit, status: :unprocessable_entity \}}, m
         assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_entity \}}, m
@@ -46,7 +46,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
       assert_instance_method :destroy, content do |m|
         assert_match %r{@post\.destroy}, m
-        assert_match %r{format\.html \{ redirect_to posts_url, notice: "Post was successfully destroyed\." \}}, m
+        assert_match %r{format\.html \{ redirect_to posts_path, notice: "Post was successfully destroyed\." \}}, m
         assert_match %r{format\.json \{ head :no_content \}}, m
       end
 
@@ -64,15 +64,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       run_generator %w(Admin::Post --model-name=Post)
       assert_file 'app/controllers/admin/posts_controller.rb' do |content|
         assert_instance_method :create, content do |m|
-          assert_match %r{format\.html \{ redirect_to admin_post_url\(@post\), notice: "Post was successfully created\." \}}, m
+          assert_match %r{format\.html \{ redirect_to \[:admin, @post\], notice: "Post was successfully created\." \}}, m
         end
 
         assert_instance_method :update, content do |m|
-          assert_match %r{format\.html \{ redirect_to admin_post_url\(@post\), notice: "Post was successfully updated\." \}}, m
+          assert_match %r{format\.html \{ redirect_to \[:admin, @post\], notice: "Post was successfully updated\." \}}, m
         end
 
         assert_instance_method :destroy, content do |m|
-          assert_match %r{format\.html \{ redirect_to admin_posts_url, notice: "Post was successfully destroyed\." \}}, m
+          assert_match %r{format\.html \{ redirect_to admin_posts_path, notice: "Post was successfully destroyed\." \}}, m
         end
       end
     end


### PR DESCRIPTION
Partially addresses https://github.com/rails/rails/issues/52756

### Problem

There is some discrepancy between Rails controller generators and jbuilder controller generators when it comes to redirects.

### Solution

This PR changes the controller generator to generate redirects with `redirect_to @post` or `_path`, in order to match the Rails codebase generators as close as possible.