### PR TITLE
Use new `params.expect` syntax instead of `params.require`

### DIFF
--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -48,13 +48,19 @@ class <%= controller_class_name %>Controller < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_<%= singular_table_name %>
+      <%- if Rails::VERSION::MAJOR >= 8 -%>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params.expect(:id)") %>
+      <%- else -%>
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+      <%- end -%>
     end
 
     # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})
+      <%- elsif Rails::VERSION::MAJOR >= 8 -%>
+      params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- else -%>
       params.require(<%= ":#{singular_table_name}" %>).permit(<%= permitted_params %>)
       <%- end -%>

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -65,13 +65,19 @@ class <%= controller_class_name %>Controller < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_<%= singular_table_name %>
+      <%- if Rails::VERSION::MAJOR >= 8 -%>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params.expect(:id)") %>
+      <%- else -%>
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+      <%- end -%>
     end
 
     # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(<%= ":#{singular_table_name}" %>, {})
+      <%- elsif Rails::VERSION::MAJOR >= 8 -%>
+      params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- else -%>
       params.require(<%= ":#{singular_table_name}" %>).permit(<%= permitted_params %>)
       <%- end -%>

--- a/test/scaffold_api_controller_generator_test.rb
+++ b/test/scaffold_api_controller_generator_test.rb
@@ -38,8 +38,17 @@ if Rails::VERSION::MAJOR > 4
           assert_match %r{@post\.destroy}, m
         end
 
+        assert_match %r{def set_post}, content
+        if Rails::VERSION::MAJOR >= 8
+          assert_match %r{params\.expect\(:id\)}, content
+        else
+          assert_match %r{params\[:id\]}, content
+        end
+
         assert_match %r{def post_params}, content
-        if Rails::VERSION::MAJOR >= 6
+        if Rails::VERSION::MAJOR >= 8
+          assert_match %r{params\.expect\(post: \[ :title, :body, images: \[\] \]\)}, content
+        elsif Rails::VERSION::MAJOR >= 6
           assert_match %r{params\.require\(:post\)\.permit\(:title, :body, images: \[\]\)}, content
         else
           assert_match %r{params\.require\(:post\)\.permit\(:title, :body, :images\)}, content
@@ -62,7 +71,11 @@ if Rails::VERSION::MAJOR > 4
         run_generator ["Message", "content:rich_text", "video:attachment", "photos:attachments"]
 
         assert_file 'app/controllers/messages_controller.rb' do |content|
-          assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+          if Rails::VERSION::MAJOR >= 8
+            assert_match %r{params\.expect\(message: \[ :content, :video, photos: \[\] \]\)}, content
+          else
+            assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+          end
         end
       end
     end

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -50,8 +50,17 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
         assert_match %r{format\.json \{ head :no_content \}}, m
       end
 
+      assert_match %r{def set_post}, content
+      if Rails::VERSION::MAJOR >= 8
+        assert_match %r{params\.expect\(:id\)}, content
+      else
+        assert_match %r{params\[:id\]}, content
+      end
+
       assert_match %r{def post_params}, content
-      if Rails::VERSION::MAJOR >= 6
+      if Rails::VERSION::MAJOR >= 8
+        assert_match %r{params\.expect\(post: \[ :title, :body, images: \[\] \]\)}, content
+      elsif Rails::VERSION::MAJOR >= 6
         assert_match %r{params\.require\(:post\)\.permit\(:title, :body, images: \[\]\)}, content
       else
         assert_match %r{params\.require\(:post\)\.permit\(:title, :body, :images\)}, content
@@ -92,7 +101,11 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       run_generator %w(Message content:rich_text video:attachment photos:attachments)
 
       assert_file 'app/controllers/messages_controller.rb' do |content|
-        assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+        if Rails::VERSION::MAJOR >= 8
+          assert_match %r{params\.expect\(message: \[ :content, :video, photos: \[\] \]\)}, content
+        else
+          assert_match %r{params\.require\(:message\)\.permit\(:content, :video, photos: \[\]\)}, content
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

PR https://github.com/rails/rails/pull/51674 updated controller generator templates in the Rails codebase. But, as DHH [explained](https://github.com/rails/rails/pull/51674#issuecomment-2336471213), we need to do the same update to templates in jbuilder, because they are used by default for new Rails apps.

## Solution

Port the changes from https://github.com/rails/rails/pull/51674 to this codebase, only for Rails versions 8.0+:

- Change templates to use `params.expect(post: [ :title, ... ])` instead of `params.require(:post).permit(:title, ...)`.

  Notice the spaces around `[` and `]` in order to be compliant with `rubocop-rails-omakase` rules, which are enabled by default for new Rails apps.
- Change templates to use `@post = params.expect(:id)` instead of `@post = params[:id]`.

cc @martinemde 