### PR TITLE
Fix regression in API controllers with view_cache_dependencies helper

### DIFF
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -20,6 +20,8 @@ class Jbuilder
           if name == 'ActionController::API'
             include ActionController::Helpers
             include ActionController::ImplicitRender
+            helper_method :combined_fragment_cache_key
+            helper_method :view_cache_dependencies
           end
         end
       end


### PR DESCRIPTION
Rails 8's API controllers now includes the `Caching` module by default (to [support](https://github.com/rails/rails/commit/c24450ac3f06bd405ec152eb6361ea01dabaa473) `rate_limit` in API controllers), but does not include the Helpers module.

This causes the jbuilder `cache` method to raise an exception because the Rails caching module does not add the `helper_method :view_cache_dependencies` since that's [only added](https://github.com/rails/rails/blob/fd975a87758713a26abe22ab1c337d4ea24c8899/actionpack/lib/abstract_controller/caching.rb#L45) if `helper_method` exists.

```ruby
helper_method :view_cache_dependencies if respond_to?(:helper_method)
```

Example error:

```bash
ActionView::Template::Error: undefined local variable or method `view_cache_dependencies' for an instance of #<Class:0x000000012a6da468>
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-a5d1e10449c6/actionview/lib/action_view/helpers/cache_helper.rb:257:in `digest_path_from_template'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-a5d1e10449c6/actionview/lib/action_view/helpers/cache_helper.rb:271:in `fragment_name_with_digest'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-a5d1e10449c6/actionview/lib/action_view/helpers/cache_helper.rb:252:in `cache_fragment_name'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/jbuilder-2.13.0/lib/jbuilder/jbuilder_template.rb:227:in `_fragment_name_with_digest'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/jbuilder-2.13.0/lib/jbuilder/jbuilder_template.rb:214:in `_cache_key'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/jbuilder-2.13.0/lib/jbuilder/jbuilder_template.rb:194:in `_cache_fragment_for'
    /Users/chris/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/jbuilder-2.13.0/lib/jbuilder/jbuilder_template.rb:69:in `cache!'
    app/views/users/_user.json.jbuilder:1:in `_app_views_users__user_json_jbuilder___1927266165303472685_95340'
```

This adds the helper method to jbuilder to ensure that caching still works without having to include Helpers in API controllers.

Previously, this worked because you could include both the Helpers and Caching modules in API controllers in the correct order.

jbuilder doesn't have a test/dummy app to write tests for this.