### PR TITLE
Force close final statement in templates

### DIFF
--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -159,7 +159,7 @@ class JbuilderTemplate < Jbuilder
         results = CollectionRenderer
           .new(@context.lookup_context, options) { |&block| _scope(&block) }
           .render_collection_with_partial(collection, partial, @context, nil)
-  
+
         array! if results.respond_to?(:body) && results.body.nil?
       else
         array!
@@ -284,7 +284,7 @@ class JbuilderHandler
   def self.call(template, source = nil)
     source ||= template.source
     # this juggling is required to keep line numbers right in the error
-    %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{source}
+    %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{source};
       json.target! unless (__already_defined && __already_defined != "method")}
   end
 end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -49,6 +49,17 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "hello", result["content"]
   end
 
+  test "partial by name with hash value omission (punning) as last statement [3.1+]" do
+    major, minor, _ = RUBY_VERSION.split(".").map(&:to_i)
+    return unless (major == 3 && minor >= 1) || major > 3
+
+    result = render(<<-JBUILDER)
+      content = "hello"
+      json.partial! "partial", content:
+    JBUILDER
+    assert_equal "hello", result["content"]
+  end
+
   test "partial by options containing nested locals" do
     result = render('json.partial! partial: "partial", locals: { content: "hello" }')
     assert_equal "hello", result["content"]


### PR DESCRIPTION
This enables Hash Shorthand / punning on your final template statement (which I think is a good thing).

This was a somewhat tricky error to track down -- but this cropped up for us as I was adding Sorbet strict typing to our view layer. An example repro on Ruby 3.1+ would be:

`example/test.json.jbuilder`:

```
foobar = "hello"
json.partial! "example/partial", foobar:
```

And:

`example/_partial.json.jbuilder`:
```
json.baz foobar
```

This would result in `{"baz": "{}"}` rather than `{"baz": "hello" }`.

Ultimately a Jbuilder template compiles to something like:

```
 def __source_json_jbuilder___2759381185109067391_7700(local_assigns, output_buffer)
            @virtual_path = "source";;__already_defined = defined?(json); json||=JbuilderTemplate.new(self);       content = "hello"
      json.partial! "partial", content:

      json.target! unless (__already_defined && __already_defined != "method")
          end
```

In cases where the final statement could be construed as still open (spanning newlines), this string munging can take the result of the `json.target!` and pull it into `local_assigns`.