### PR TITLE
Test against Rails 8 and fix Rails 7 logger dependency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} (${{ matrix.gemfile }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.gemfile == 'rails_head' }}
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
@@ -19,23 +19,25 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
 
         gemfile:
           - "rails_7_0"
           - "rails_7_1"
+          - "rails_8_0"
           - "rails_head"
 
         exclude:
           - ruby: '3.0'
+            gemfile: rails_8_0
+          - ruby: '3.0'
             gemfile: rails_head
-
-        include:
+          - ruby: '3.1'
+            gemfile: rails_8_0
           - ruby: '3.1'
             gemfile: rails_head
-          - ruby: '3.2'
-            gemfile: rails_head
-          - ruby: head
-            gemfile: rails_head
+          - ruby: '3.4'
+            gemfile: rails_7_0
 
     steps:
       - uses: actions/checkout@v4

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,16 @@
-if RUBY_VERSION >= "2.7.0"
-  appraise "rails-7-0" do
-    gem "rails", "~> 7.0.0"
-  end
+appraise "rails-7-0" do
+  gem "rails", "~> 7.0.0"
+  gem "concurrent-ruby", "< 1.3.5" # to avoid problem described in https://github.com/rails/rails/pull/54264
+end
 
-  appraise "rails-7-1" do
-    gem "rails", "~> 7.1.0"
-  end
+appraise "rails-7-1" do
+  gem "rails", "~> 7.1.0"
+end
 
-  appraise "rails-head" do
-    gem "rails", github: "rails/rails", branch: "main"
-  end
+appraise "rails-8-0" do
+  gem "rails", "~> 8.0.0"
+end
+
+appraise "rails-head" do
+  gem "rails", github: "rails/rails", branch: "main"
 end

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gem "rake"
 gem "mocha", require: false
 gem "appraisal"
-gem "rails", "~> 7.0.0"
-gem "concurrent-ruby", "< 1.3.5"
+gem "rails", "~> 8.0.0"
 
 gemspec path: "../"


### PR DESCRIPTION
This fixes a few things with CI and adds more coverage:

1. Fixes Rails 7.0 with the `logger` dependency that was removed in concurrent-ruby 1.3.5
2. Adds a Rails 8.0 appraisal
3. Uses the latest Ubuntu LTS for running tests