### PR TITLE
Add status: :see_other to update action

### DIFF
--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   def update
     respond_to do |format|
       if @<%= orm_instance.update("#{singular_table_name}_params") %>
-        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %> }
+        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>, status: :see_other }
         format.json { render :show, status: :ok, location: <%= "@#{singular_table_name}" %> }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -57,7 +57,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= orm_instance.destroy %>
 
     respond_to do |format|
-      format.html { redirect_to <%= index_helper %>_path, status: :see_other, notice: <%= %("#{human_name} was successfully destroyed.") %> }
+      format.html { redirect_to <%= index_helper %>_path, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other }
       format.json { head :no_content }
     end
   end

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -38,7 +38,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :update, content do |m|
-        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully updated\." \}}, m
+        assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully updated\.", status: :see_other \}}, m
         assert_match %r{format\.json \{ render :show, status: :ok, location: @post \}}, m
         assert_match %r{format\.html \{ render :edit, status: :unprocessable_entity \}}, m
         assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_entity \}}, m
@@ -46,7 +46,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
       assert_instance_method :destroy, content do |m|
         assert_match %r{@post\.destroy}, m
-        assert_match %r{format\.html \{ redirect_to posts_path, status: :see_other, notice: "Post was successfully destroyed\." \}}, m
+        assert_match %r{format\.html \{ redirect_to posts_path, notice: "Post was successfully destroyed\.", status: :see_other \}}, m
         assert_match %r{format\.json \{ head :no_content \}}, m
       end
 
@@ -77,11 +77,11 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
         end
 
         assert_instance_method :update, content do |m|
-          assert_match %r{format\.html \{ redirect_to \[:admin, @post\], notice: "Post was successfully updated\." \}}, m
+          assert_match %r{format\.html \{ redirect_to \[:admin, @post\], notice: "Post was successfully updated\.", status: :see_other \}}, m
         end
 
         assert_instance_method :destroy, content do |m|
-          assert_match %r{format\.html \{ redirect_to admin_posts_path, status: :see_other, notice: "Post was successfully destroyed\." \}}, m
+          assert_match %r{format\.html \{ redirect_to admin_posts_path, notice: "Post was successfully destroyed\.", status: :see_other \}}, m
         end
       end
     end


### PR DESCRIPTION
I noticed today that Rails' scaffold controller adds `status: :see_other` for the `update` action, but jbuilder didn't. This updates it to match.

I also reordered the arguments to match the Rails template so it'll match and be easier to spot differences.

Tests won't pass until #582 is merged.

