### PR TITLE
Optimize key formatter

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -15,14 +15,14 @@ class Jbuilder
   def initialize(options = nil)
     @attributes = {}
 
-    if options
-      @key_formatter = options[:key_formatter]
-      @ignore_nil = options[:ignore_nil]
-      @deep_format_keys = options[:deep_format_keys]
-    else
+    if options.nil?
       @key_formatter = @@key_formatter
       @ignore_nil = @@ignore_nil
       @deep_format_keys = @@deep_format_keys
+    else
+      @key_formatter = options[:key_formatter]
+      @ignore_nil = options[:ignore_nil]
+      @deep_format_keys = options[:deep_format_keys]
     end
 
     yield self if ::Kernel.block_given?

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -15,9 +15,15 @@ class Jbuilder
   def initialize(options = nil)
     @attributes = {}
 
-    @key_formatter = options&.[](:key_formatter) || @@key_formatter
-    @ignore_nil = options&.[](:ignore_nil) || @@ignore_nil
-    @deep_format_keys = options&.[](:deep_format_keys) || @@deep_format_keys
+    if options
+      @key_formatter = options[:key_formatter]
+      @ignore_nil = options[:ignore_nil]
+      @deep_format_keys = options[:deep_format_keys]
+    else
+      @key_formatter = @@key_formatter
+      @ignore_nil = @@ignore_nil
+      @deep_format_keys = @@deep_format_keys
+    end
 
     yield self if ::Kernel.block_given?
   end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -12,7 +12,7 @@ class Jbuilder
   @@ignore_nil    = false
   @@deep_format_keys = false
 
-  def initialize(options = {})
+  def initialize(options = nil)
     @attributes = {}
 
     @key_formatter = options&.[](:key_formatter) || @@key_formatter
@@ -100,13 +100,13 @@ class Jbuilder
   #
   #   { "_first_name": "David" }
   #
-  def key_format!(*args)
-    @key_formatter = KeyFormatter.new(*args)
+  def key_format!(...)
+    @key_formatter = KeyFormatter.new(...)
   end
 
   # Same as the instance method key_format! except sets the default.
-  def self.key_format(*args)
-    @@key_formatter = KeyFormatter.new(*args)
+  def self.key_format(...)
+    @@key_formatter = KeyFormatter.new(...)
   end
 
   # If you want to skip adding nil values to your JSON hash. This is useful

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -12,18 +12,11 @@ class Jbuilder
   @@ignore_nil    = false
   @@deep_format_keys = false
 
-  def initialize(options = nil)
+  def initialize(key_formatter: @@key_formatter, ignore_nil: @@ignore_nil, deep_format_keys: @@deep_format_keys)
     @attributes = {}
-
-    if options.nil?
-      @key_formatter = @@key_formatter
-      @ignore_nil = @@ignore_nil
-      @deep_format_keys = @@deep_format_keys
-    else
-      @key_formatter = options[:key_formatter]
-      @ignore_nil = options[:ignore_nil]
-      @deep_format_keys = options[:deep_format_keys]
-    end
+    @key_formatter = key_formatter
+    @ignore_nil = ignore_nil
+    @deep_format_keys = deep_format_keys
 
     yield self if ::Kernel.block_given?
   end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -15,9 +15,9 @@ class Jbuilder
   def initialize(options = {})
     @attributes = {}
 
-    @key_formatter = options.fetch(:key_formatter){ @@key_formatter ? @@key_formatter.clone : nil}
-    @ignore_nil = options.fetch(:ignore_nil, @@ignore_nil)
-    @deep_format_keys = options.fetch(:deep_format_keys, @@deep_format_keys)
+    @key_formatter = options&.[](:key_formatter) || @@key_formatter
+    @ignore_nil = options&.[](:ignore_nil) || @@ignore_nil
+    @deep_format_keys = options&.[](:deep_format_keys) || @@deep_format_keys
 
     yield self if ::Kernel.block_given?
   end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -12,13 +12,18 @@ class Jbuilder
   @@ignore_nil    = false
   @@deep_format_keys = false
 
-  def initialize(key_formatter: @@key_formatter, ignore_nil: @@ignore_nil, deep_format_keys: @@deep_format_keys)
+  def initialize(
+    key_formatter: @@key_formatter,
+    ignore_nil: @@ignore_nil,
+    deep_format_keys: @@deep_format_keys,
+    &block
+  )
     @attributes = {}
     @key_formatter = key_formatter
     @ignore_nil = ignore_nil
     @deep_format_keys = deep_format_keys
 
-    yield self if ::Kernel.block_given?
+    yield self if block
   end
 
   # Yields a builder and automatically turns the result into a JSON string

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -13,7 +13,8 @@ class JbuilderTemplate < Jbuilder
   def initialize(context, options = nil)
     @context = context
     @cached_root = nil
-    super(options)
+
+    options.nil? ? super() : super(**options)
   end
 
   # Generates JSON using the template specified with the `:partial` option. For example, the code below will render

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -10,10 +10,10 @@ class JbuilderTemplate < Jbuilder
 
   self.template_lookup_options = { handlers: [:jbuilder] }
 
-  def initialize(context, *args)
+  def initialize(context, options = nil)
     @context = context
     @cached_root = nil
-    super(*args)
+    super(options)
   end
 
   # Generates JSON using the template specified with the `:partial` option. For example, the code below will render

--- a/lib/jbuilder/key_formatter.rb
+++ b/lib/jbuilder/key_formatter.rb
@@ -3,24 +3,28 @@ require 'jbuilder/jbuilder'
 class Jbuilder
   class KeyFormatter
     def initialize(*formats, **formats_with_options)
-      @cache =
-        Hash.new do |hash, key|
-          value = key.is_a?(Symbol) ? key.name : key.to_s
-
-          formats.each do |func|
-            value = func.is_a?(Proc) ? func.call(value) : value.send(func)
-          end
-
-          formats_with_options.each do |func, params|
-            value = func.is_a?(Proc) ? func.call(value, *params) : value.send(func, *params)
-          end
-
-          hash[key] = value
-        end
+      @mutex = Mutex.new
+      @formats = formats
+      @formats_with_options = formats_with_options
+      @cache = {}
     end
 
     def format(key)
-      @cache[key]
+      @mutex.synchronize do
+        @cache[key] ||= begin
+          value = key.is_a?(Symbol) ? key.name : key.to_s
+
+          @formats.each do |func|
+            value = func.is_a?(Proc) ? func.call(value) : value.send(func)
+          end
+
+          @formats_with_options.each do |func, params|
+            value = func.is_a?(Proc) ? func.call(value, *params) : value.send(func, *params)
+          end
+
+          value
+        end
+      end
     end
   end
 end

--- a/lib/jbuilder/key_formatter.rb
+++ b/lib/jbuilder/key_formatter.rb
@@ -1,34 +1,26 @@
 require 'jbuilder/jbuilder'
-require 'active_support/core_ext/array'
 
 class Jbuilder
   class KeyFormatter
-    def initialize(*args)
-      @format = {}
-      @cache = {}
+    def initialize(*formats, **formats_with_options)
+      @cache =
+        Hash.new do |hash, key|
+          value = key.is_a?(Symbol) ? key.name : key.to_s
 
-      options = args.extract_options!
-      args.each do |name|
-        @format[name] = []
-      end
-      options.each do |name, parameters|
-        @format[name] = parameters
-      end
-    end
+          formats.each do |func|
+            value = func.is_a?(Proc) ? func.call(value) : value.send(func)
+          end
 
-    def initialize_copy(original)
-      @cache = {}
+          formats_with_options.each do |func, params|
+            value = func.is_a?(Proc) ? func.call(value, *params) : value.send(func, *params)
+          end
+
+          hash[key] = value
+        end
     end
 
     def format(key)
-      @cache[key] ||= @format.inject(key.to_s) do |result, args|
-        func, args = args
-        if ::Proc === func
-          func.call result, *args
-        else
-          result.send func, *args
-        end
-      end
+      @cache[key]
     end
   end
 end

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -784,14 +784,6 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal ['camelStyle'], result.keys
   end
 
-  test 'do not use default key formatter directly' do
-    Jbuilder.key_format
-    jbuild{ |json| json.key 'value' }
-    formatter = Jbuilder.send(:class_variable_get, '@@key_formatter')
-    cache = formatter.instance_variable_get('@cache')
-    assert_empty cache
-  end
-
   test 'ignore_nil! without a parameter' do
     result = jbuild do |json|
       json.ignore_nil!

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -784,6 +784,14 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal ['camelStyle'], result.keys
   end
 
+  test 'use default key formatter when configured' do
+    Jbuilder.key_format
+    jbuild{ |json| json.key 'value' }
+    formatter = Jbuilder.send(:class_variable_get, '@@key_formatter')
+    cache = formatter.instance_variable_get('@cache')
+    assert_includes cache, :key
+  end
+
   test 'ignore_nil! without a parameter' do
     result = jbuild do |json|
       json.ignore_nil!


### PR DESCRIPTION
Makes a few optimizations to the `Jbuilder::KeyFormatter` integration:
- Uses `*args` and `**kwargs` to handle the provided format symbols. This saves on having to compute a list of formatters from the provided `options`, and saves on some memory allocations for the empty `[]` arrays that represented "no parameters". While this is definitely a micro-optimization (ie. it would only be a hot code path of a template itself uses `json.key_format!`) it does make things easier to read.
- Uses `.each` over `.inject` when computing cache keys, which is slightly faster.
- Saves on some memory allocation when initializing either `Jbuilder` or `JbuilderTemplate` with no `options`, which is what the template handler does (`json||=JbuilderTemplate.new(self)`). No need to allocation an empty `Hash` for this.
- Optimizes `Jbuilder` initialization by using key arguments instead of `fetch` when grabbing values from `options`
- Saves on a memory allocation for both `key_format!` and `self.key_format` by simply passing args through to `KeyFormatter.new`. This is a micro-optimization, but can be a hotter code path if a template uses `json.key_format!`.

Now the _big_ change here is that the key formatter cache is now no longer clobbered between template renders. What was originally happening was that when you configured a global key formatter with something like `Jbuilder.key_format = camelize: :lower`, it would be `.clone`d whenever a new `Jbuilder` was initialized, which happens before each template render. When it was cloned, the cache would be wiped it when `KeyFormatter#initialize_copy` ran. This meant that each template render - and thus each API request - would start with a fresh cache. This meant that you would have to re-pay the cost to format the keys all over again.

I'm not sure why it was done this way. When configuring a global key formatter for Jbuilder, I would expect that to be used across requests so that the cost to generate the keys could amortize as the service runs. This behaviour was [originally added](https://github.com/rails/jbuilder/pull/54) _twelve years_ ago, specifically in [this commit](https://github.com/rails/jbuilder/commit/d136416c9d3b4ac29cfe18c3689aaeb5a7314a4b), but it's not clear to me what the intent or motivation was to do that.

The other difference is that a `Mutex` has been added to the cache lookup to keep it thread safe. This allows us to have a single shared cache per `KeyFormatter`. The previous implementation was thread safe because each render would have its own instance of the cache (and perhaps that's why the cache would be a fresh `Hash` whenever `KeyFormatter` was `clone`d), and the addition of the `Mutex` respects that behaviour.