### PR TITLE
Optimize internal `extract!` calls to save on memory allocation

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -286,7 +286,7 @@ class Jbuilder
   end
 
   def _extract_hash_values(object, attributes)
-    attributes.each{ |key| _set_value key, _format_keys(object[key]) }
+    attributes.each{ |key| _set_value key, _format_keys(object.fetch(key)) }
   end
 
   def _extract_method_values(object, attributes)

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -58,7 +58,7 @@ class Jbuilder
     else
       # json.author @post.creator, :name, :email_address
       # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
-      _merge_block(key){ extract! value, *args }
+      _merge_block(key){ _extract value, args }
     end
 
     _set_value key, result
@@ -215,7 +215,7 @@ class Jbuilder
     elsif ::Kernel.block_given?
       _map_collection(collection, &block)
     elsif attributes.any?
-      _map_collection(collection) { |element| extract! element, *attributes }
+      _map_collection(collection) { |element| _extract element, attributes }
     else
       _format_keys(collection.to_a)
     end
@@ -241,18 +241,14 @@ class Jbuilder
   #
   #   json.(@person, :name, :age)
   def extract!(object, *attributes)
-    if ::Hash === object
-      _extract_hash_values(object, attributes)
-    else
-      _extract_method_values(object, attributes)
-    end
+    _extract object, attributes
   end
 
   def call(object, *attributes, &block)
     if ::Kernel.block_given?
       array! object, &block
     else
-      extract! object, *attributes
+      _extract object, attributes
     end
   end
 
@@ -281,8 +277,16 @@ class Jbuilder
 
   private
 
+  def _extract(object, attributes)
+    if ::Hash === object
+      _extract_hash_values(object, attributes)
+    else
+      _extract_method_values(object, attributes)
+    end
+  end
+
   def _extract_hash_values(object, attributes)
-    attributes.each{ |key| _set_value key, _format_keys(object.fetch(key)) }
+    attributes.each{ |key| _set_value key, _format_keys(object[key]) }
   end
 
   def _extract_method_values(object, attributes)


### PR DESCRIPTION
Simply optimizes internal calls to `extract!` to avoid extra memory allocations to splat the `*attributes`. Both `_extract_hash_values` and `_extract_method_values` accept an array for `attributes`, so no need to re-splat it by calling `extract!`, which then splats it again.

Solution is to implement a private `_extract` that just accepts an array, which can be used internally.

A simple way to compare it is with the `call` DSL, which was just running `extract!` underneath.

```ruby
# person = { first_name: 'John', last_name: 'Doe', age: 30, city: 'New York' }

json.(person, :first_name, :last_name, :age, :city)
```

```
Warming up --------------------------------------
              before   156.678k i/100ms
               after   176.882k i/100ms
Calculating -------------------------------------
              before      1.674M (± 1.6%) i/s  (597.37 ns/i) -      8.461M in   5.055454s
               after      1.802M (± 2.0%) i/s  (554.82 ns/i) -      9.021M in   5.007138s

Comparison:
               after:  1802399.6 i/s
              before:  1673994.1 i/s - 1.08x  slower
```

```
Calculating -------------------------------------
              before   320.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
               after   240.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
               after:        240 allocated
              before:        320 allocated - 1.33x more
```

This change has no impact in using `json.extract!` directly.

```ruby
# person = { first_name: 'John', last_name: 'Doe', age: 30, city: 'New York' }

json.extract! person, :first_name, :last_name, :age, :city
```

```
Calculating -------------------------------------
              before   240.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
               after   240.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
              before:        240 allocated
               after:        240 allocated - same
```