### PR TITLE
Ensure that `Jbuilder.encode` properly forwards arguments to `.new`

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -28,8 +28,8 @@ class Jbuilder
   end
 
   # Yields a builder and automatically turns the result into a JSON string
-  def self.encode(*args, &block)
-    new(*args, &block).target!
+  def self.encode(...)
+    new(...).target!
   end
 
   BLANK = Blank.new

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -936,4 +936,11 @@ class JbuilderTest < ActiveSupport::TestCase
     result = JSON.load(Jbuilder.encode { |json| json.time Time.parse("2018-05-13 11:51:00.485 -0400") })
     assert_equal "2018-05-13T11:51:00.485-04:00", result["time"]
   end
+
+  test "encode forwards options to new" do
+    Jbuilder.encode(key_formatter: 1, ignore_nil: 2) do |json|
+      assert_equal 1, json.instance_eval{ @key_formatter }
+      assert_equal 2, json.instance_eval{ @ignore_nil }
+    end
+  end
 end


### PR DESCRIPTION
The initializer previously accepted an options hash, but now takes kwargs. So the encode method also needs to accept (and forward) kwargs.

Without this change, existing code like this:

```ruby
Jbuilder.encode(ignore_nil: true) do |json|
  # ...
end
```

raises an exception. The test I've added here fails with:

```
Error:
JbuilderTest#test_encode_forwards_options_to_new:
ArgumentError: wrong number of arguments (given 1, expected 0)
    lib/jbuilder.rb:16:in 'initialize'
    lib/jbuilder.rb:32:in 'Class#new'
    lib/jbuilder.rb:32:in 'Jbuilder.encode'
    test/jbuilder_test.rb:941:in 'block in <class:JbuilderTest>'
```

Fixes #602 
