### PR TITLE
Use `:unprocessable_content` for scaffolds with Rack 3.1 or higher

### DIFF
--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -15,6 +15,10 @@ module Rails
         def permitted_params
           attributes_names.map { |name| ":#{name}" }.join(', ')
         end unless private_method_defined? :permitted_params
+
+        def status_unprocessable_content
+          ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(422) rescue :unprocessable_content
+        end
     end
   end
 end

--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -25,7 +25,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.save %>
       render :show, status: :created, location: <%= "@#{singular_table_name}" %>
     else
-      render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
+      render json: <%= "@#{orm_instance.errors}" %>, status: :<%= status_unprocessable_content.to_s %>
     end
   end
 
@@ -35,7 +35,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
       render :show, status: :ok, location: <%= "@#{singular_table_name}" %>
     else
-      render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
+      render json: <%= "@#{orm_instance.errors}" %>, status: :<%= status_unprocessable_content.to_s %>
     end
   end
 

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -33,8 +33,8 @@ class <%= controller_class_name %>Controller < ApplicationController
         format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %> }
         format.json { render :show, status: :created, location: <%= "@#{singular_table_name}" %> }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
+        format.html { render :new, status: :<%= status_unprocessable_content.to_s %> }
+        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :<%= status_unprocessable_content.to_s %> }
       end
     end
   end
@@ -46,8 +46,8 @@ class <%= controller_class_name %>Controller < ApplicationController
         format.html { redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>, status: :see_other }
         format.json { render :show, status: :ok, location: <%= "@#{singular_table_name}" %> }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
+        format.html { render :edit, status: :<%= status_unprocessable_content.to_s %> }
+        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :<%= status_unprocessable_content.to_s %> }
       end
     end
   end

--- a/test/scaffold_api_controller_generator_test.rb
+++ b/test/scaffold_api_controller_generator_test.rb
@@ -24,12 +24,20 @@ class ScaffoldApiControllerGeneratorTest < Rails::Generators::TestCase
         assert_match %r{@post = Post\.new\(post_params\)}, m
         assert_match %r{@post\.save}, m
         assert_match %r{render :show, status: :created, location: @post}, m
-        assert_match %r{render json: @post\.errors, status: :unprocessable_entity}, m
+        if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3.1")
+          assert_match %r{render json: @post\.errors, status: :unprocessable_entity}, m
+        else
+          assert_match %r{render json: @post\.errors, status: :unprocessable_content}, m
+        end
       end
 
       assert_instance_method :update, content do |m|
         assert_match %r{render :show, status: :ok, location: @post}, m
-        assert_match %r{render json: @post.errors, status: :unprocessable_entity}, m
+        if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3.1")
+          assert_match %r{render json: @post.errors, status: :unprocessable_entity}, m
+        else
+          assert_match %r{render json: @post.errors, status: :unprocessable_content}, m
+        end
       end
 
       assert_instance_method :destroy, content do |m|

--- a/test/scaffold_controller_generator_test.rb
+++ b/test/scaffold_controller_generator_test.rb
@@ -33,15 +33,25 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
         assert_match %r{@post\.save}, m
         assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully created\." \}}, m
         assert_match %r{format\.json \{ render :show, status: :created, location: @post \}}, m
-        assert_match %r{format\.html \{ render :new, status: :unprocessable_entity \}}, m
-        assert_match %r{format\.json \{ render json: @post\.errors, status: :unprocessable_entity \}}, m
+        if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3.1")
+          assert_match %r{format\.html \{ render :new, status: :unprocessable_entity \}}, m
+          assert_match %r{format\.json \{ render json: @post\.errors, status: :unprocessable_entity \}}, m
+        else
+          assert_match %r{format\.html \{ render :new, status: :unprocessable_content \}}, m
+          assert_match %r{format\.json \{ render json: @post\.errors, status: :unprocessable_content \}}, m
+        end
       end
 
       assert_instance_method :update, content do |m|
         assert_match %r{format\.html \{ redirect_to @post, notice: "Post was successfully updated\.", status: :see_other \}}, m
         assert_match %r{format\.json \{ render :show, status: :ok, location: @post \}}, m
-        assert_match %r{format\.html \{ render :edit, status: :unprocessable_entity \}}, m
-        assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_entity \}}, m
+        if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3.1")
+          assert_match %r{format\.html \{ render :edit, status: :unprocessable_entity \}}, m
+          assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_entity \}}, m
+        else
+          assert_match %r{format\.html \{ render :edit, status: :unprocessable_content \}}, m
+          assert_match %r{format\.json \{ render json: @post.errors, status: :unprocessable_content \}}, m
+        end
       end
 
       assert_instance_method :destroy, content do |m|


### PR DESCRIPTION
### Motivation / Background

In Rack v3.1.0, the symbol for HTTP status code 422 was changed from `:unprocessable_entity` to `:unprocessable_content`.
Rails supports both `:unprocessable_entity` and `:unprocessable_content`, but for scaffolds generated when using Rack 3.1 or higher, it now uses `:unprocessable_content`.

- https://github.com/rack/rack/pull/2137
- https://github.com/rails/rails/pull/53383

### Detail

This Pull Request updates controllers generated by scaffolds so that when using Rack v3.1 or higher, the HTTP status code returned in JSON format responses is changed from `:unprocessable_entity` to `:unprocessable_content`, aligning with the behavior of Rails scaffolds.

When using Rack v3.1 or higher, the generated scaffold code is updated as follows:
```diff
# $ bundle exec rails generate scaffold Post title:string
# app/controllers/posts_controller.rb
...
  # POST /posts or /posts.json
  def create
...
      else
        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @post.errors, status: :unprocessable_content }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
      end
    end
  end
```
When using Rack v3.0 or lower, the generated code continues to use `:unprocessable_entity` as before.

### Additional information

Since the jbuilder gem does not depend on actionpack (specifically action_dispatch) in its gemspec,  
the choice between `:unprocessable_entity` and `:unprocessable_content` is determined by Rack (not by `ActionDispatch::Constants::UNPROCESSABLE_CONTENT`):
```ruby
# lib/generators/rails/scaffold_controller_generator.rb
        def status_unprocessable_content
          ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(422) rescue :unprocessable_content
        end
```

The behavior of `Rack::Utils::SYMBOL_TO_STATUS_CODE.key(422)` depends on the Rack version:

```ruby
Rack::Utils::SYMBOL_TO_STATUS_CODE.key(422)
=> :unprocessable_content # rack 3.1 or higher
=> :unprocessable_entity # rack 3.0 and below
```

The code for `Rack::Utils::SYMBOL_TO_STATUS_CODE` can be found here:
https://github.com/rack/rack/blob/v3.2.1/lib/rack/utils.rb#L564-L566
https://github.com/rack/rack/blob/2.0.0/lib/rack/utils.rb#L581-L583
