### PR TITLE
fix: update overidden signature to match upstream

### DIFF
--- a/lib/jbuilder/collection_renderer.rb
+++ b/lib/jbuilder/collection_renderer.rb
@@ -44,8 +44,8 @@ class Jbuilder
         @options[:locals].fetch(:json)
       end
 
-      def collection_with_template(view, template, layout, collection)
-        super(view, template, layout, ScopedIterator.new(collection, @scope))
+      def collection_with_template(view, template, layout, collection, *args)
+        super(view, template, layout, ScopedIterator.new(collection, @scope), *args)
       end
   end
 


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/107ee64909b978476b318e36f317cfa2a747d1ad, the signature of `collection_with_template` has been updated but the override in `lib/jbuilder/collection_renderer.rb` is still using the old one, resulting in `ActionView::Template::Error: wrong number of arguments (given 5, expected 4)`