### PR TITLE
fix: Preserve locals when rendering inline partial for object

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ json.array! @comments do |comment|
   end
 end
 
-# => [ { "body": "great post...", "author": { "first_name": "Joe", "last_name": "Bloe" }} ]
+# => [ { "body": "great post...", "author": { "first_name": "Joe", "last_name": "Blow" }} ]
 ```
 
 ## Array Attributes
@@ -209,6 +209,13 @@ the partial.
 json.partial! 'comments/comments', comments: @message.comments
 ```
 
+You can also render an object to a partial inline under a key.
+
+```ruby
+json.post @post, partial: 'posts/post', as: :post
+# => { "post": { "title": "Hello World!", "author": { "name": "David" } } }
+```
+
 It's also possible to render collections of partials:
 
 ```ruby
@@ -219,9 +226,24 @@ json.partial! 'posts/post', collection: @posts, as: :post
 
 # or
 json.partial! partial: 'posts/post', collection: @posts, as: :post
+```
 
-# or
+You can also render to a collection of partials inline under a key.
+
+```ruby
 json.comments @post.comments, partial: 'comments/comment', as: :comment
+# => { "comments": [{ "content": "Hello everyone!" }, { "content": "To you my good sir!" }] }
+```
+
+You can also provide other locals to the partial you're rendering to.
+
+```ruby
+# Provide the `include_body` local to the partial when rendering a single object
+json.post @post, partial: 'posts/post', as: :post, include_body: true
+
+# Provide a local to the partial when rendering a collection.
+# Each item in the collection will render with `include_author: true`.
+json.comments @post.comments, partial: 'comments/comment', as: :comment, include_author: true
 ```
 
 The `as: :some_symbol` is used with partials. It will take care of mapping the passed in object to a variable for the
@@ -321,7 +343,7 @@ This will include both records as part of the cache key and updating either of t
 ## Formatting Keys
 
 Keys can be auto formatted using `key_format!`, this can be used to convert
-keynames from the standard ruby_format to camelCase:
+key names from the standard ruby_format to camelCase:
 
 ```ruby
 json.key_format! camelize: :lower

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -174,13 +174,9 @@ class JbuilderTemplate < Jbuilder
         array!
       end
     else
-      _render_partial options
+      options[:locals][:json] = self
+      @context.render options
     end
-  end
-
-  def _render_partial(options)
-    options[:locals][:json] = self
-    @context.render options
   end
 
   def _cache_fragment_for(key, options, &block)
@@ -241,7 +237,7 @@ class JbuilderTemplate < Jbuilder
       end
     else
       _scope do
-        options[:locals] = { options[:as] => object }
+        options[options[:as]] = object
         _render_partial_with_options options
       end
     end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -3,10 +3,8 @@ require "action_view/testing/resolvers"
 
 class JbuilderTemplateTest < ActiveSupport::TestCase
   POST_PARTIAL = <<-JBUILDER
-    # locals: (json:, post:, include_title: false)
-
     json.extract! post, :id, :body
-    json.title post.title if include_title
+    json.title post.title if local_assigns.fetch(:include_title, false)
     json.author do
       first_name, last_name = post.author_name.split(nil, 2)
       json.first_name first_name

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -3,7 +3,10 @@ require "action_view/testing/resolvers"
 
 class JbuilderTemplateTest < ActiveSupport::TestCase
   POST_PARTIAL = <<-JBUILDER
+    # locals: (json:, post:, include_title: false)
+
     json.extract! post, :id, :body
+    json.title post.title if include_title
     json.author do
       first_name, last_name = post.author_name.split(nil, 2)
       json.first_name first_name
@@ -30,7 +33,7 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
   }
 
   AUTHORS = [ "David Heinemeier Hansson", "Pavel Pravosud" ].cycle
-  POSTS   = (1..10).collect { |i| Post.new(i, "Post ##{i}", AUTHORS.next) }
+  POSTS   = (1..10).collect { |i| Post.new(i, "Title #{i}", "Post ##{i}", AUTHORS.next) }
 
   setup { Rails.cache.clear }
 
@@ -136,6 +139,18 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal [], render('json.array! @posts, partial: "post", as: :post', posts: nil)
   end
 
+  test "single partial under key" do
+    result = render('json.post @post, partial: "post", as: :post', post: POSTS.first)
+    assert_equal "Post #1", result["post"]["body"]
+    assert_equal "Heinemeier Hansson", result["post"]["author"]["last_name"]
+    assert_equal "David", result["post"]["author"]["first_name"]
+  end
+
+  test 'single partial under key with local' do
+    result = render('json.post @post, partial: "post", as: :post, include_title: true', post: POSTS.first)
+    assert_equal "Title 1", result["post"]["title"]
+  end
+
   test "array of partials under key" do
     result = render('json.posts @posts, partial: "post", as: :post', posts: POSTS)
     assert_equal 10, result["posts"].count
@@ -144,13 +159,19 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "Pavel", result["posts"][5]["author"]["first_name"]
   end
 
+  test "array of partials under key with local" do
+    result = render('json.posts @posts, partial: "post", as: :post, include_title: true', posts: POSTS)
+    assert_equal "Title 1", result["posts"][0]["title"]
+    assert_equal "Title 2", result["posts"][1]["title"]
+  end
+
   test "empty array of partials under key from nil collection" do
     Jbuilder::CollectionRenderer.expects(:new).never
     result = render('json.posts @posts, partial: "post", as: :post', posts: nil)
     assert_equal [], result["posts"]
   end
 
-  test "empty array of partials under key from an empy collection" do
+  test "empty array of partials under key from an empty collection" do
     Jbuilder::CollectionRenderer.expects(:new).never
     result = render('json.posts @posts, partial: "post", as: :post', posts: [])
     assert_equal [], result["posts"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ end
 
 Jbuilder::CollectionRenderer.collection_cache = Rails.cache
 
-class Post < Struct.new(:id, :body, :author_name)
+class Post < Struct.new(:id, :title, :body, :author_name)
   def cache_key
     "post-#{id}"
   end


### PR DESCRIPTION
Ran into an odd bug. Given a template like

```ruby
# locals (json:, foo:, my_local: 'default')

json.extract! foo, :id, :name
json.myLocal my_local
```

Rendering to a collection inline like

```ruby
json.foos, @foos, partial: 'foos/foo', as: :foo, my_local: 'custom'
```

Would correctly render with the value of `my_local` with the value of `'custom'`

```json
{
  "foos": [
    "id": 1,
    "name": "Test",
    "myLocal": "custom"
  ]
}
```

But rendering a single object _wasn't_ picking up the value for the local

```ruby
json.foo, @foo, partial: 'foos/foo', as: :foo, my_local: 'custom'
```

```json
{
  "foo": {
    "id": 1,
    "name": "Test",
    "myLocal": "default"
  }
}
```

If the partial _didn't_ have a default value set for strict locals

```ruby
# locals (json:, foo:, my_local:)

json.extract! foo, :id, :name
json.myLocal my_local
```

The following 

```ruby
json.foo, @foo, partial: 'foos/foo', as: :foo, my_local: 'custom'
```

would raise

```
ActionView::Template::Error: missing local: :my_local for app/views/foos/_foo.json.jbuilder...
```

The reason is because this render path in `_set_inline_partial` would set a key for `locals` before the render is done in `_render_partial_with_options`.  `_render_partial_with_options` attempts to pluck key args for `locals`, but since the key is already there, they are effectively ignored.

This _may_ have been a regression introduced by #591 which made it no longer `reverse_merge!` on the `locals` key. I haven't verified this, though.

The fix was to not have `_set_inline_partial` set `locals`, and instead defer that logic to `_render_partial_with_options`.

I added some extra tests cases to cover this.
- A test for rendering an object to an inline partial (there were no tests for this)
- A test for rendering an object to an inline partial with locals
- A test for rendering a collection to an inline partial with locals

I also updated the docs to include an example for rendering an object to an inline partial. This is supported by the library, but was seemingly undocumented. Also documented rendering to partials inline with other locals, which was also supported by the library but seemingly undocumented.

As an aside: With some small refactoring, I think we can drop the need for the intermediary `_set_inline_partial` method. It doesn't do too much and I think the coordination of `locals` can all be handled within `_render_partial_with_options`. This would save a bit on indirection and also align everything to the same render path. Outside of the scope of this PR, but perhaps something I can try later.
