### PR TITLE
Make method_missing private

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -272,9 +272,10 @@ class Jbuilder
     @attributes.to_json
   end
 
-  private
-
   alias_method :method_missing, :set!
+  private :method_missing
+
+  private
 
   def _extract(object, attributes)
     if ::Hash === object

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -141,9 +141,10 @@ class JbuilderTemplate < Jbuilder
     end
   end
 
-  private
-
   alias_method :method_missing, :set!
+  private :method_missing
+
+  private
 
   def _render_partial_with_options(options)
     options[:locals] ||= options.except(:partial, :as, :collection, :cached)

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -39,6 +39,11 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "hello", result["content"]
   end
 
+  test "method_missing can be used as a key" do
+    result = render('json.method_missing "hello"')
+    assert_equal({ "method_missing" => "hello" }, result)
+  end
+
   test "partial by name with top-level locals" do
     result = render('json.partial! "partial", content: "hello"')
     assert_equal "hello", result["content"]

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -61,6 +61,14 @@ class JbuilderTest < ActiveSupport::TestCase
     assert_equal 'hello', result['content']
   end
 
+  test 'method_missing key' do
+    result = jbuild do |json|
+      json.method_missing 'hello'
+    end
+
+    assert_equal 'hello', result['method_missing']
+  end
+
   test 'single key with false value' do
     result = jbuild do |json|
       json.content false


### PR DESCRIPTION
`alias_method :method_missing, :set!` was placed after the `private` directive, but `alias_method` does not respect the modifier, it copies the visibility of the source method. Since `#set!` is public, the alias silently made `method_missing` public, overriding the private one inherited from `BasicObject`.

Add an explicit `private :method_missing` after the alias (above the `private` directive, for clarity) so that `#method_missing` is properly private.

As a side effect, `json.method_missing "hello"` now reaches `#set!` with both a key and a value `set!(:method_missing, "hello")`, like any other DSL call, and produces `{"method_missing": "hello"}`. Before this patch the public alias was called directly as `set!("hello")`, a single-arg call that was silently dropped because `_set_value` short-circuits on a `BLANK` value, so the key never appeared in the output at all.

Discovered by accident while migrating a Rails app to Jbuilder, where an object happened to expose `method_missing` as a key and produced unexpected output.