### PR TITLE
Fix raw TypeError/NoMethodError when reopening array or null scope with a block

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -305,6 +305,8 @@ class Jbuilder
   end
 
   def _merge_block(key)
+    ::Kernel.raise NullError.build(key) if @attributes.nil?
+    ::Kernel.raise ArrayError.build(key) if ::Array === @attributes
     current_value = _blank? ? BLANK : @attributes.fetch(_key(key), BLANK)
     ::Kernel.raise NullError.build(key) if current_value.nil?
     new_value = _scope{ yield self }

--- a/test/jbuilder_test.rb
+++ b/test/jbuilder_test.rb
@@ -888,6 +888,15 @@ class JbuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test 'throws ArrayError when trying to add a key to an array using block syntax' do
+    assert_raise Jbuilder::ArrayError do
+      jbuild do |json|
+        json.array! %w[foo bar]
+        json.fizz { json.buzz "value" }
+      end
+    end
+  end
+
   test 'throws NullError when trying to add properties to null' do
     assert_raise Jbuilder::NullError do
       jbuild do |json|
@@ -898,6 +907,15 @@ class JbuilderTest < ActiveSupport::TestCase
   end
 
   test 'throws NullError when trying to add properties to null using block syntax' do
+    assert_raise Jbuilder::NullError do
+      jbuild do |json|
+        json.null!
+        json.foo { json.bar 'value' }
+      end
+    end
+  end
+
+  test 'throws NullError when trying to add properties to a previously nulled key using block syntax' do
     assert_raise Jbuilder::NullError do
       jbuild do |json|
         json.author do


### PR DESCRIPTION
Ran into this while poking at edge cases: `json.array! [1,2,3]` followed by `json.foo { json.bar "x" }` blows up with a raw `TypeError: no implicit conversion of String into Integer` instead of the library's own `Jbuilder::ArrayError`. Same story after `json.null!` — you get `NoMethodError: undefined method 'fetch' for nil` instead of `Jbuilder::NullError`.

The non-block form (`json.foo "bar"`) already gets this right through `_set_value`, which checks whether `@attributes` is an array or nil before touching it. `_merge_block` (used for the block form) skipped straight to `@attributes.fetch(...)`, so it never got a chance to raise the friendly error - Ruby's own array/nil methods raised first. Added the same checks there, in the same order `_set_value` uses, and added two tests covering both cases.