### PR TITLE
Register dependency tracker so nested partials invalidate parent caches

### DIFF
--- a/lib/jbuilder/jbuilder_dependency_tracker.rb
+++ b/lib/jbuilder/jbuilder_dependency_tracker.rb
@@ -25,6 +25,10 @@ class Jbuilder::DependencyTracker
         (['"])([^'"]+)\1            # quoted value
       /x
 
+  def self.supports_view_paths?
+    true
+  end
+
   def self.call(name, template, view_paths = nil)
     new(name, template, view_paths).dependencies
   end

--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -8,7 +8,10 @@ class Jbuilder
     initializer :jbuilder do
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
+
+        require 'action_view/dependency_tracker'
         require 'jbuilder/jbuilder_dependency_tracker'
+        ActionView::DependencyTracker.register_tracker :jbuilder, Jbuilder::DependencyTracker
       end
 
       module ::ActionController

--- a/test/jbuilder_dependency_tracker_test.rb
+++ b/test/jbuilder_dependency_tracker_test.rb
@@ -8,6 +8,22 @@ class FakeTemplate
     end
 end
 
+FakeResolvedPath = Struct.new(:prefix, :virtual_path) do
+    def to_s
+      virtual_path
+    end
+end
+
+class FakeViewPath
+    def initialize(*template_paths)
+      @template_paths = template_paths
+    end
+
+    def all_template_paths
+      @template_paths
+    end
+end
+
 
 class JbuilderDependencyTrackerTest < ActiveSupport::TestCase
     def make_tracker(name, source)
@@ -67,5 +83,24 @@ class JbuilderDependencyTrackerTest < ActiveSupport::TestCase
       RUBY
 
       assert_equal %w[path/to/partial], dependencies
+    end
+
+    test 'is registered as the dependency tracker for the :jbuilder handler' do
+      handler = ActionView::Template.handler_for_extension(:jbuilder)
+      template = FakeTemplate.new("json.partial! 'path/to/partial'", handler)
+
+      dependencies = ActionView::DependencyTracker.find_dependencies('jbuilder_template', template, [])
+
+      assert_equal %w[path/to/partial], dependencies
+    end
+
+    test 'receives the view paths so wildcard dependencies resolve' do
+      handler = ActionView::Template.handler_for_extension(:jbuilder)
+      template = FakeTemplate.new('# Template Dependency: comments/*', handler)
+      view_paths = [ FakeViewPath.new(FakeResolvedPath.new('comments', 'comments/_comment')) ]
+
+      dependencies = ActionView::DependencyTracker.find_dependencies('jbuilder_template', template, view_paths)
+
+      assert_equal %w[comments/_comment], dependencies
     end
 end


### PR DESCRIPTION
We ran into a caching issue at Basecamp with a template that looked like this: 

```
json.cache! ... do
  # ...
  
    json.people people, partial: "people/person", as: :person
end
```

We changed the `people/_person.json.jbuilder` template and deployed, yet responses using that template kept returning a stale cached version of the person. 

We traced this down to nothing registering Jbuilder's dependency tracker with Action View. Its railtie requires it, but nothing registers it with `ActionView::DependencyTracker`. Without a registered tracker, [`find_dependencies`](https://github.com/rails/rails/blob/f011d1218bdd77857f30ce3964eef186f0f14de5/actionview/lib/action_view/digestor.rb#L55) returns `[]` for every `.jbuilder` template, so the digestor sees no nested-partial dependencies: a `json.cache!` fragment that renders inner partials never mixes those partials' digests into its own cache key. Editing an inner partial then leaves outer fragments serving stale cached JSON until they happen to invalidate for some unrelated reason. ERB doesn't have this problem because [Action View registers `ERBTracker`](https://github.com/rails/rails/blob/f011d1218bdd77857f30ce3964eef186f0f14de5/actionview/lib/action_view.rb#L103).

This is a regression from #504, which rewrote the tracker as a standalone class and dropped the `register_tracker :jbuilder` call (and the `ERBTracker` inheritance that used to supply it) without re-adding it. It has shipped unregistered since 2.12.0.

Register the tracker from the same `on_load(:action_view)` block that registers the template handler, and declare `supports_view_paths?` so `register_tracker passes` the view paths through to the tracker. Otherwise, Rails wraps it in a lambda that drops them and the tracker's own wildcard (`# Template Dependency: foo/*`) resolution silently returns nothing.