### PR TITLE
Register dependency tracker

### DIFF
--- a/lib/jbuilder/jbuilder_dependency_tracker.rb
+++ b/lib/jbuilder/jbuilder_dependency_tracker.rb
@@ -25,6 +25,10 @@ class Jbuilder::DependencyTracker
         (['"])([^'"]+)\1            # quoted value
       /x
 
+  def self.supports_view_paths?
+    true
+  end
+
   def self.call(name, template, view_paths = nil)
     new(name, template, view_paths).dependencies
   end

--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -8,7 +8,9 @@ class Jbuilder
     initializer :jbuilder do
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jbuilder, JbuilderHandler
+        require 'action_view/dependency_tracker'
         require 'jbuilder/jbuilder_dependency_tracker'
+        ActionView::DependencyTracker.register_tracker :jbuilder, Jbuilder::DependencyTracker
       end
 
       module ::ActionController

--- a/test/jbuilder_dependency_tracker_test.rb
+++ b/test/jbuilder_dependency_tracker_test.rb
@@ -77,4 +77,26 @@ class JbuilderDependencyTrackerTest < ActiveSupport::TestCase
 
       assert_equal %w[path/to/partial], dependencies
     end
+
+    test 'supports view paths' do
+      assert_predicate Jbuilder::DependencyTracker, :supports_view_paths?
+    end
+
+    test 'resolves wildcard dependencies through the view paths passed by Action View' do
+      handler = ActionView::Template.handler_for_extension(:jbuilder)
+      template = FakeTemplate.new("# Template Dependency: path/to/*", handler)
+      view_paths = [FakeViewPath.new([FakeTemplatePath.new('path/to', 'partial')])]
+
+      dependencies = ActionView::DependencyTracker.find_dependencies('name', template, view_paths)
+
+      assert_equal %w[path/to/partial], dependencies
+    end
 end
+
+FakeTemplatePath = Struct.new(:prefix, :name) do
+  def to_s
+    "#{prefix}/#{name}"
+  end
+end
+
+FakeViewPath = Struct.new(:all_template_paths)

--- a/test/jbuilder_dependency_tracker_test.rb
+++ b/test/jbuilder_dependency_tracker_test.rb
@@ -68,4 +68,13 @@ class JbuilderDependencyTrackerTest < ActiveSupport::TestCase
 
       assert_equal %w[path/to/partial], dependencies
     end
+
+    test 'is registered as the tracker for jbuilder templates' do
+      handler = ActionView::Template.handler_for_extension(:jbuilder)
+      template = FakeTemplate.new("json.partial! 'path/to/partial'", handler)
+
+      dependencies = ActionView::DependencyTracker.find_dependencies('name', template, [])
+
+      assert_equal %w[path/to/partial], dependencies
+    end
 end


### PR DESCRIPTION
While working on the dependency tracker in Rails (https://github.com/rails/rails/pull/57948) I realized Jbuilder wasn't registering its dependency tracker (from https://github.com/rails/jbuilder/pull/504). This just plugs it in.

```console
$ cat app/views/root/index.json.jbuilder 
json.partial! "root/greeting"
$ cat app/views/root/_greeting.json.jbuilder 
json.greeting "greeting v1"
```

**Before:**
```console
bin/rails runner '
finder = ApplicationController.new.lookup_context
finder.formats = [:json]
template = finder.find("root/index")
p ActionView::DependencyTracker.find_dependencies(template.virtual_path, template, finder.view_paths)'
[]
```

**After:**
```console
bin/rails runner '
finder = ApplicationController.new.lookup_context
finder.formats = [:json]
template = finder.find("root/index")
p ActionView::DependencyTracker.find_dependencies(template.virtual_path, template, finder.view_paths)'
```

I also made sure wildcards are supported by adding `Jbuilder::DependencyTracker.supports_view_paths?`.