### PR TITLE
Optimize `_blank?`

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -377,7 +377,7 @@ class Jbuilder
   end
 
   def _blank?(value=@attributes)
-    BLANK == value
+    Blank === value
   end
 end
 

--- a/lib/jbuilder/blank.rb
+++ b/lib/jbuilder/blank.rb
@@ -2,10 +2,6 @@
 
 class Jbuilder
   class Blank
-    def ==(other)
-      super || Blank === other
-    end
-
     def empty?
       true
     end


### PR DESCRIPTION
Switches `_blank?` from `BLANK == value` to `Blank === value`.

Originally `_blank?` did a Ruby-level dispatch to `Blank#==`, which itself calls `super` (for an identity check) and then `Blank === other`. We can short circuit this to simply be `Blank === other`. This gives us the same result for less work because `Blank#==` would always return `true` for _any_  `Blank` instance. We don't actually need to an identity check.

```ruby
blank1 = Jbuilder::Blank.new
blank2 = Jbuilder::Blank.new

puts blank1 == blank2 # true
puts blank2 == blank1 # true
```

Below is an IPS benchmark against a simple builder that exercises `_blank` a few times.

```ruby
# frozen_string_literal: true

require 'benchmark/ips'
require_relative 'lib/jbuilder'

json = Jbuilder.new

Benchmark.ips do |x|
  x.report('old') do |n|
    i = 0
    while i < n
      i += 1

      json.set! :foo do
        json.set! :bar, 123
      end
    end
  end

  x.report('new') do |n|
    i = 0
    while i < n
      i += 1

      json.set! :foo do
        json.set! :bar, 123
      end
    end
  end

  x.hold! 'ips_results'
  x.compare! order: :baseline
end
```

Without YJIT 

```
ruby 4.0.7 (2026-09-15 revision 229531a6cf) +PRISM [arm64-darwin23]
Warming up --------------------------------------
                 old    55.923k i/100ms
                 new    70.938k i/100ms
Calculating -------------------------------------
                 old    563.384k (± 1.4%) i/s    (1.77 μs/i) -      2.852M in   5.062397s
                 new    716.586k (± 1.4%) i/s    (1.40 μs/i) -      3.618M in   5.048717s

Comparison:
old:   563383.9 i/s
new:   716585.6 i/s - 1.27x  faster
```

With YJIT 

```
ruby 4.0.7 (2026-09-15 revision 229531a6cf) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                 old   169.546k i/100ms
                 new   178.359k i/100ms
Calculating -------------------------------------
                 old      1.712M (± 2.3%) i/s  (584.09 ns/i) -      8.647M in   5.050534s
Calculating -------------------------------------
                 new      1.783M (± 3.3%) i/s  (560.71 ns/i) -      8.918M in   5.000406s

Comparison:
old:  1712065.7 i/s
new:  1783445.2 i/s - same-ish: difference falls within error
```