### PR TITLE
Support integrating with Action View layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,25 @@ json.partial! 'sub_template', locals: { user: user }
 json.partial! 'sub_template', user: user
 ```
 
+## Layouts
+
+You can rely on Rails' built-in support for layout templates defined in
+`app/views/layouts/`. Layouts can be used to extract properties or structures
+that are shared across responses.
+
+For example, a `PostsController` that inherits from `ApplicationController` will
+render its templates declared in `app/views/posts/` *into* the layout declared
+in `app/views/layouts/application.json.jbuilder`:
+
+```ruby
+# app/views/layouts/application.json.jbuilder
+json.merge! yield
+json.servedAt Time.current
+
+# app/views/posts/index.json.jbuilder
+json.partial! 'posts/post', collection: @posts, as: :post
+```
+
 ## Null Values
 
 You can explicitly make Jbuilder object return null if you want:

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -2,6 +2,7 @@
 
 require 'jbuilder/jbuilder'
 require 'jbuilder/collection_renderer'
+require 'jbuilder/rendering_helper'
 require 'action_dispatch/http/mime_type'
 require 'active_support/cache'
 
@@ -14,6 +15,7 @@ class JbuilderTemplate < Jbuilder
 
   def initialize(context, options = nil)
     @context = context
+    @context.extend(RenderingHelper) unless @context.is_a?(RenderingHelper)
     @cached_root = nil
 
     options.nil? ? super() : super(**options)
@@ -116,7 +118,7 @@ class JbuilderTemplate < Jbuilder
   end
 
   def target!
-    @cached_root || super
+    (@cached_root || super).tap { @context._jbuilder = self }
   end
 
   def array!(collection = EMPTY_ARRAY, *args, &block)

--- a/lib/jbuilder/rendering_helper.rb
+++ b/lib/jbuilder/rendering_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Jbuilder
+  module RenderingHelper # :nodoc:
+    def _layout_for(*args, &block)
+      if block.nil? && (content = @_jbuilder)
+        @_jbuilder = nil
+        content
+      else
+        super
+      end
+    end
+
+    def _jbuilder=(content)
+      @_jbuilder = content
+    end
+  end
+end

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -2,6 +2,11 @@ require "test_helper"
 require "action_view/testing/resolvers"
 
 class JbuilderTemplateTest < ActiveSupport::TestCase
+  LAYOUT = <<-JBUILDER
+    json.layout true
+    json.merge! yield
+  JBUILDER
+
   POST_PARTIAL = <<-JBUILDER
     json.extract! post, :id, :body
     json.title post.title if local_assigns.fetch(:include_title, false)
@@ -20,6 +25,10 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     json.extract! racer, :id, :name
     json.highlighted local_assigns.fetch(:highlighted, false)
   JBUILDER
+
+  LAYOUTS = {
+    "layouts/test.json.jbuilder"  => LAYOUT
+  }
 
   PARTIALS = {
     "_partial.json.jbuilder"      => "json.content content",
@@ -44,6 +53,12 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
   test "method_missing can be used as a key" do
     result = render('json.method_missing "hello"')
     assert_equal({ "method_missing" => "hello" }, result)
+  end
+
+  test "renders into layout" do
+    result = render('json.template true', layout: "layouts/test")
+    assert_equal true, result["layout"]
+    assert_equal true, result["template"]
   end
 
   test "partial by name with top-level locals" do
@@ -448,8 +463,9 @@ class JbuilderTemplateTest < ActiveSupport::TestCase
     end
 
     def render_without_parsing(source, assigns = {})
-      view = build_view(fixtures: PARTIALS.merge("source.json.jbuilder" => source), assigns: assigns)
-      view.render(template: "source")
+      layout = assigns.delete(:layout)
+      view = build_view(fixtures: PARTIALS.merge(LAYOUTS, "source.json.jbuilder" => source), assigns: assigns)
+      view.render(template: "source", layout: layout)
     end
 
     def build_view(options = {})


### PR DESCRIPTION
Related to https://github.com/rails/jbuilder/issues/250 
Related to https://github.com/rails/jbuilder/issues/172

Add support for Rails' built-in layout templates defined in `app/views/layouts/`. Layouts can be used to extract properties or structures that are shared across responses.

For example, a `PostsController` that inherits from `ApplicationController` will render its templates declared in `app/views/posts/` *into* the layout declared in
`app/views/layouts/application.json.jbuilder`:

```ruby
# app/views/layouts/application.json.jbuilder
json.merge! yield
json.servedAt Time.current

# app/views/posts/index.json.jbuilder
json.partial! 'posts/post', collection: @posts, as: :post
```